### PR TITLE
Mejora UX/UI en pantalla de Ventas (Papelitos)

### DIFF
--- a/Views/Auth/Index.cshtml
+++ b/Views/Auth/Index.cshtml
@@ -95,27 +95,28 @@
 
         .login-dark form .btn-primary {
             height: 48px;
-            border: none;
             border-radius: 12px;
             margin-top: 8px;
-            background: linear-gradient(135deg, #3e6f82, #5fa6b8);
-            color: #fff;
+            background: var(--primary);
+            border-color: var(--primary);
+            color: #fff !important;
             font-weight: 600;
             letter-spacing: 0.3px;
-            box-shadow: 0 10px 20px rgba(62, 111, 130, 0.28);
+            box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
             transition: all 0.2s ease;
         }
 
             .login-dark form .btn-primary:hover,
             .login-dark form .btn-primary:focus {
-                background: linear-gradient(135deg, #355f70, #4f95a6);
+                background: var(--primary-strong);
+                border-color: var(--primary-strong);
                 transform: translateY(-1px);
-                box-shadow: 0 14px 24px rgba(62, 111, 130, 0.34);
+                box-shadow: 0 14px 24px rgba(37, 99, 235, 0.32);
             }
 
             .login-dark form .btn-primary:active {
                 transform: translateY(0);
-                box-shadow: 0 8px 16px rgba(62, 111, 130, 0.25);
+                box-shadow: 0 8px 16px rgba(37, 99, 235, 0.24);
             }
 
         .login-dark .alert {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -9,81 +9,88 @@
     var sum = subsum * cant;
 }
 
-<h2 class="fw-bold mb-4">@ViewData["Title"]</h2>
-
-<hr />
-
-<form asp-action="Copy">
-    <div class="form-group col-md-4">
-        <div class="input-group mb-3">
-            <input type="text" class="form-control col-md-2" placeholder="Papelito" name="id">
-            <input type="submit" class="btn btn-success" value="Copiar">
-        </div>
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+    <div>
+        <h2 class="fw-bold mb-1">@ViewData["Title"]</h2>
+        <p class="text-muted mb-0">Configura sorteo, cliente y números para generar el papelito de venta.</p>
     </div>
-</form>
+    <form asp-action="Copy" class="w-100 w-lg-auto">
+        <div class="input-group shadow-sm">
+            <span class="input-group-text bg-white border-end-0">
+                <span class="material-icons" style="font-size:18px;">content_copy</span>
+            </span>
+            <input type="text" class="form-control border-start-0" placeholder="Copiar desde papelito #" name="id">
+            <input type="submit" class="btn btn-success px-3" value="Copiar">
+        </div>
+    </form>
+</div>
 
 <form asp-action="Save">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-    <div class="row g-2">
-        <div class="form-group col-md-2">
-            <label asp-for="Id" class="control-label">Papelito</label>
-            <input asp-for="Id" class="form-control" disabled readonly />
-        </div>
-        <div class="form-group col-md-2">
-            <label asp-for="DrawDate" class="control-label">Fecha</label>
-            <input asp-for="DrawDate" onchange="redirectToCreate('dateString', 'DrawDate')" type="date" min="@DateTime.Now.ToString("yyyy-MM-dd")" class="form-control" />
-        </div>
-        <div class="form-group col-md-4">
-            <label asp-for="SelectedLotteries" class="control-label">Sorteos</label>
-            <div class="position-relative">
-                <div id="customSelect" class="form-select" onclick="toggleDropdown()">
-                    <span id="selectedLotteriesText">Seleccione uno o varios</span>
+    <div class="card shadow-sm border-0 mb-3">
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="form-group col-md-2">
+                    <label asp-for="Id" class="control-label fw-semibold">Papelito</label>
+                    <input asp-for="Id" class="form-control bg-light" disabled readonly />
                 </div>
+                <div class="form-group col-md-3">
+                    <label asp-for="DrawDate" class="control-label fw-semibold">Fecha de sorteo</label>
+                    <input asp-for="DrawDate" onchange="redirectToCreate('dateString', 'DrawDate')" type="date" min="@DateTime.Now.ToString("yyyy-MM-dd")" class="form-control" />
+                </div>
+                <div class="form-group col-md-4">
+                    <label asp-for="SelectedLotteries" class="control-label fw-semibold">Sorteos</label>
+                    <div class="position-relative">
+                        <div id="customSelect" class="form-select" onclick="toggleDropdown()">
+                            <span id="selectedLotteriesText">Seleccione uno o varios</span>
+                        </div>
 
 
-                <!-- UL con checkboxes (se muestra al hacer clic) -->
-                <ul id="customDropdown"
-                    class="list-group position-absolute w-100"
-                    style="z-index: 1000; display: none; max-height: 400px; overflow-y: auto; background: white; border: 1px solid #ced4da; border-top: none;">
-                    @if(ViewData["Names"] is IList<Lottery> lotteries)
-                    {
-                        <li class="list-group-item bg-light">
-                            <input type="checkbox"
-                                   class="form-check-input me-2"
-                                   id="selectAll"
-                                   onchange="toggleSelectAll(this)"
-                                    @(Model.SelectedLotteries.Count() == lotteries.Count() ? "checked" : "indeterminate") />
-                            <label class="form-check-label fw-bold" for="selectAll">Seleccionar todos</label>
-                        </li>
-                        foreach(var item in lotteries)
+                        <!-- UL con checkboxes (se muestra al hacer clic) -->
+                        <ul id="customDropdown"
+                            class="list-group position-absolute w-100 shadow-sm"
+                            style="z-index: 1000; display: none; max-height: 320px; overflow-y: auto; background: white; border: 1px solid #ced4da; border-top: none;">
+                            @if(ViewData["Names"] is IList<Lottery> lotteries)
+                            {
+                                <li class="list-group-item bg-light">
+                                    <input type="checkbox"
+                                           class="form-check-input me-2"
+                                           id="selectAll"
+                                           onchange="toggleSelectAll(this)"
+                                            @(Model.SelectedLotteries.Count() == lotteries.Count() ? "checked" : "indeterminate") />
+                                    <label class="form-check-label fw-bold" for="selectAll">Seleccionar todos</label>
+                                </li>
+                                foreach(var item in lotteries)
+                                {
+                                    <li class="list-group-item">
+                                        <input type="checkbox"
+                                               class="form-check-input child-checkbox me-2"
+                                               name="SelectedLotteries"
+                                               value="@item.Name"
+                                               id="lottery_@item.Order"
+                                               onchange="updateSelected()"
+                                               @(Model.SelectedLotteries.Contains(item.Name) ? "checked" : "") />
+                                        <label class="form-check-label" for="lottery_@item.Order">@item.Name</label>
+                                    </li>
+                                }
+                            }
+                        </ul>
+                    </div>
+                </div>       
+                <div class="form-group col-md-3">
+                    <label asp-for="ClientId" class="control-label fw-semibold">Cliente</label>
+                    <select asp-for="ClientId" class="form-control form-select" onchange="redirectToCreate('clientId', 'ClientId', )">
+                        <option value="-1" selected>Seleccione un nombre</option>
+                        @if(ViewData["Clients"] is not null)
                         {
-                            <li class="list-group-item">
-                                <input type="checkbox"
-                                       class="form-check-input child-checkbox me-2"
-                                       name="SelectedLotteries"
-                                       value="@item.Name"
-                                       id="lottery_@item.Order"
-                                       onchange="updateSelected()"
-                                       @(Model.SelectedLotteries.Contains(item.Name) ? "checked" : "") />
-                                <label class="form-check-label" for="lottery_@item.Order">@item.Name</label>
-                            </li>
+                            @foreach(var item in ViewData["Clients"] as IList<Client> ?? new List<Client>())
+                            {
+                                <option value="@item.Id">@item.Name</option>
+                            }
                         }
-                    }
-                </ul>
+                    </select>
+                </div>
             </div>
-        </div>       
-        <div class="form-group col-md-4">
-            <label asp-for="ClientId" class="control-label">Cliente</label>
-            <select asp-for="ClientId" class="form-control form-select" onchange="redirectToCreate('clientId', 'ClientId', )">
-                <option value="-1" selected>Seleccione un nombre</option>
-                @if(ViewData["Clients"] is not null)
-                {
-                    @foreach(var item in ViewData["Clients"] as IList<Client> ?? new List<Client>())
-                    {
-                        <option value="@item.Id">@item.Name</option>
-                    }
-                }
-            </select>
         </div>
     </div>
     <div class="d-flex justify-content-end">
@@ -97,7 +104,7 @@
 
 @if(Model?.SelectedLotteries.Any() ?? false)
 {
-    <div class="alert alert-info d-flex align-items-start gap-2 flex-wrap mt-1">
+    <div class="alert alert-info d-flex align-items-start gap-2 flex-wrap mt-1 shadow-sm">
         <span class="fw-bold">
             <i class="bi bi-check-circle-fill me-1"></i> Sorteos seleccionados:
         </span>
@@ -116,9 +123,15 @@
     <div class="container-fluid mb-2">
         <div class="row">
             <div class="col-lg-8">
-                <div class="table-responsive container overflow-auto">
-                    <table class="table">
-                        <thead>
+                <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <h5 class="mb-0 fw-bold">Números cargados</h5>
+                            <span class="badge text-bg-light border">Total líneas: @Model.Numbers.Count()</span>
+                        </div>
+                        <div class="table-responsive container overflow-auto">
+                            <table class="table table-hover align-middle mb-0">
+                                <thead class="table-light">
                             <tr>
                                 <th></th>
                                 <th>Numero</th>
@@ -127,42 +140,44 @@
                                 <th></th>
                                 <th></th>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @foreach(var item in Model.Numbers)
-                            {
-                                <tr>
-                                    <td></td>
-                                    <td>@item.Value</td>
-                                    <td>@item.Amount</td>
-                                    <td>@item.Busted</td>
-                                    <td>
-                                        <!-- Remove -->
-                                        <button type="button" class="btn" onclick="showPartial('removePartial-@Model.Id-@item.Id')">
-                                            <span class="material-icons icon icon-danger">delete</span>
-                                        </button>
-                                    </td>
-                                </tr>
-                                <tr id="removePartial-@Model.Id-@item.Id">
-                                    <td colspan="6">
-                                        <partial name="_Remove" model="new LotteryConnectionModel{PaperId= Model.Id, LineId= item.Id??1}" />
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
+                                </thead>
+                                <tbody>
+                                    @foreach(var item in Model.Numbers)
+                                    {
+                                        <tr>
+                                            <td></td>
+                                            <td class="fw-semibold">@item.Value</td>
+                                            <td>₡ @item.Amount.ToString("N0")</td>
+                                            <td>₡ @item.Busted.ToString("N0")</td>
+                                            <td>
+                                                <!-- Remove -->
+                                                <button type="button" class="btn" onclick="showPartial('removePartial-@Model.Id-@item.Id')">
+                                                    <span class="material-icons icon icon-danger">delete</span>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr id="removePartial-@Model.Id-@item.Id" style="display:none;">
+                                            <td colspan="6">
+                                                <partial name="_Remove" model="new LotteryConnectionModel{PaperId= Model.Id, LineId= item.Id??1}" />
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
 
             </div>
             <div class="col-lg-4">
-                <div class="card" style="background: linear-gradient(135deg, #3B82F6, #64b5f6);">
+                <div class="card text-white border-0 shadow-sm" style="background: linear-gradient(135deg, #3B82F6, #64b5f6);">
                     <div class="card-body">
                         <h2 class="card-title">Resumen</h2>
-                        <p class="card-text">Monto Total: @Model.Numbers.Sum(x => x.Amount)</p>
-                        <p class="card-text">Reventado Total: @Model.Numbers.Sum(x => x.Busted)</p>
+                        <p class="card-text mb-1">Monto Total: ₡ @Model.Numbers.Sum(x => x.Amount).ToString("N0")</p>
+                        <p class="card-text">Reventado Total: ₡ @Model.Numbers.Sum(x => x.Busted).ToString("N0")</p>
                         <hr>
-                        <p class="card-text" style="font-weight: bold; font-size: 1rem;">Total Papelito: @subsum</p>
-                        <p class="card-text" style="font-weight: bold; font-size: 1.2rem;">Total General: @sum</p>
+                        <p class="card-text mb-1" style="font-weight: bold; font-size: 1rem;">Total Papelito: ₡ @subsum.ToString("N0")</p>
+                        <p class="card-text mb-0" style="font-weight: bold; font-size: 1.2rem;">Total General: ₡ @sum.ToString("N0")</p>
                     </div>
                 </div>
 
@@ -254,10 +269,15 @@
 
         function updateSelected() {
             const dropdown = document.getElementById('customDropdown');
+            if (!dropdown) return;
             const checkboxes = dropdown.querySelectorAll('input[name="SelectedLotteries"]');
             const checked = dropdown.querySelectorAll('input[name="SelectedLotteries"]:checked');
             const selectAll = dropdown.querySelector('#selectAll');
             const values = Array.from(checked).map(cb => cb.value);
+            const selectedLabel = document.getElementById('selectedLotteriesText');
+            if (selectedLabel) {
+                selectedLabel.textContent = values.length ? values.join(', ') : 'Seleccione uno o varios';
+            }
 
             // Crear input temporal con valores
             const tempInput = document.createElement('input');
@@ -272,6 +292,7 @@
 
         function toggleSelectAll(masterCheckbox) {
             const dropdown = document.getElementById('customDropdown');
+            if (!dropdown) return;
             const checkboxes = dropdown.querySelectorAll('input[name="SelectedLotteries"]');
 
             checkboxes.forEach(cb => cb.checked = masterCheckbox.checked);
@@ -292,9 +313,15 @@
             const checkboxes = document.querySelectorAll('.child-checkbox');
             const checkedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
             const selectAll = document.getElementById('selectAll');
-
-            selectAll.checked = checkedCount === checkboxes.length;
-            selectAll.indeterminate = checkedCount > 0 && checkedCount < checkboxes.length;
+            const selectedLabel = document.getElementById('selectedLotteriesText');
+            const selectedValues = Array.from(checkboxes).filter(cb => cb.checked).map(cb => cb.value);
+            if (selectAll) {
+                selectAll.checked = checkedCount === checkboxes.length && checkboxes.length > 0;
+                selectAll.indeterminate = checkedCount > 0 && checkedCount < checkboxes.length;
+            }
+            if (selectedLabel) {
+                selectedLabel.textContent = selectedValues.length ? selectedValues.join(', ') : 'Seleccione uno o varios';
+            }
 
             // Mostrar el dropdown si viene keepSelection=true en la URL
             const urlParams = new URLSearchParams(window.location.search);

--- a/Views/Lottery/Index.cshtml
+++ b/Views/Lottery/Index.cshtml
@@ -103,14 +103,37 @@
         <div class="tab-pane fade" id="papelitos-pane" role="tabpanel" aria-labelledby="papelitos-tab" tabindex="0">
             <div class="card shadow-sm border-0">
                 <div class="card-body">
+                    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
+                        <div>
+                            <h5 class="mb-1 fw-bold">Ventas por papelito</h5>
+                            <p class="text-muted mb-0">Revisa montos, reventados y estado de sorteo en un solo lugar.</p>
+                        </div>
+                        <div class="d-flex flex-column flex-sm-row gap-2 w-100 w-lg-auto">
+                            <div class="input-group input-group-sm">
+                                <span class="input-group-text bg-white"><span class="material-icons" style="font-size:18px;">search</span></span>
+                                <input id="papelitoFilter" type="text" class="form-control" placeholder="Buscar por papelito o sorteo" />
+                            </div>
+                            <div class="form-check form-switch d-flex align-items-center m-0 px-2 border rounded">
+                                <input class="form-check-input me-2" type="checkbox" id="pendingOnly">
+                                <label class="form-check-label small text-nowrap" for="pendingOnly">Solo pendientes</label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2 mb-3">
+                        <span class="badge rounded-pill text-bg-light border">Papelitos: @totalPapelitos</span>
+                        <span class="badge rounded-pill text-bg-light border">Monto: ₡ @totalMonto.ToString("N0")</span>
+                        <span class="badge rounded-pill text-bg-light border">Reventado: ₡ @totalReventado.ToString("N0")</span>
+                    </div>
+
                     <div class="table-responsive">
-                        <table class="table table-hover align-middle">
+                        <table class="table table-hover align-middle" id="papelitosTable">
                             <thead class="table-light">
                                 <tr>
                                     <th>Papelito</th>
+                                    <th>Sorteos</th>
+                                    <th>Creación</th>
                                     <th>Sorteo</th>
-                                    <th>Fecha de creación</th>
-                                    <th>Fecha de sorteo</th>
                                     <th class="text-end">Monto</th>
                                     <th class="text-end">Reventado</th>
                                     <th class="text-end">Total</th>
@@ -125,11 +148,32 @@
                                     total = monto + reventado;
                                     totales += total;
 
-                                    <tr>
+                                    <tr data-paper-id="@item.Id" data-pending="@(item.DrawDate > DateTime.Now)">
                                         <td class="fw-semibold">#@item.Id</td>
-                                        <td><span class="badge bg-secondary">@item.Lottery</span></td>
-                                        <td>@item.CreationDate.ToString("g")</td>
-                                        <td>@item.DrawDate.ToString("g")</td>
+                                        <td>
+                                            <div class="d-flex flex-wrap gap-1">
+                                                @foreach (var lot in (item.Lottery ?? string.Empty).Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                                                {
+                                                    <span class="badge text-bg-secondary-subtle border">@lot</span>
+                                                }
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="small fw-semibold">@item.CreationDate.ToString("dd/MM/yyyy")</div>
+                                            <div class="text-muted small">@item.CreationDate.ToString("hh:mm tt")</div>
+                                        </td>
+                                        <td>
+                                            <div class="small fw-semibold">@item.DrawDate.ToString("dd/MM/yyyy")</div>
+                                            <div class="text-muted small">@item.DrawDate.ToString("hh:mm tt")</div>
+                                            @if (item.DrawDate > DateTime.Now)
+                                            {
+                                                <span class="badge rounded-pill text-bg-warning-subtle border mt-1">Pendiente</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge rounded-pill text-bg-success-subtle border mt-1">Jugado</span>
+                                            }
+                                        </td>
                                         <td class="text-end">₡ @monto.ToString("N0")</td>
                                         <td class="text-end">₡ @reventado.ToString("N0")</td>
                                         <td class="text-end fw-bold">₡ @total.ToString("N0")</td>
@@ -173,6 +217,9 @@
                                 </tr>
                             </tfoot>
                         </table>
+                    </div>
+                    <div id="papelitosNoResults" class="alert alert-light border text-center mt-3 d-none mb-0">
+                        No hay resultados para el filtro aplicado.
                     </div>
                 </div>
             </div>
@@ -238,6 +285,48 @@ else
                 var id = $(this).data("id");
                 $("#delete-partial-" + id).toggle();
             });
+
+            function filterPapelitos() {
+                var query = ($("#papelitoFilter").val() || "").toLowerCase().trim();
+                var onlyPending = $("#pendingOnly").is(":checked");
+                var visibleRows = 0;
+
+                $("#papelitosTable tbody tr").not("[id^='delete-partial-']").each(function() {
+                    var row = $(this);
+                    var rowText = row.text().toLowerCase();
+                    var isPending = (row.data("pending") === true || row.data("pending") === "True");
+                    var matchQuery = !query || rowText.indexOf(query) >= 0;
+                    var matchPending = !onlyPending || isPending;
+                    var show = matchQuery && matchPending;
+
+                    row.toggle(show);
+                    var deleteRow = $("#delete-partial-" + row.data("paper-id"));
+                    if (!show) {
+                        deleteRow.hide();
+                    }
+
+                    if (show) {
+                        visibleRows++;
+                    }
+                });
+
+                $("#papelitosNoResults").toggleClass("d-none", visibleRows > 0);
+            }
+
+            $("#papelitoFilter").on("input", filterPapelitos);
+            $("#pendingOnly").on("change", filterPapelitos);
         });
     </script>
 }
+
+<style>
+    #papelitos-pane .table thead th {
+        white-space: nowrap;
+    }
+
+    #papelitos-pane .badge.text-bg-secondary-subtle,
+    #papelitos-pane .badge.text-bg-warning-subtle,
+    #papelitos-pane .badge.text-bg-success-subtle {
+        color: #212529;
+    }
+</style>

--- a/Views/Lottery/Index.cshtml
+++ b/Views/Lottery/Index.cshtml
@@ -103,37 +103,14 @@
         <div class="tab-pane fade" id="papelitos-pane" role="tabpanel" aria-labelledby="papelitos-tab" tabindex="0">
             <div class="card shadow-sm border-0">
                 <div class="card-body">
-                    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
-                        <div>
-                            <h5 class="mb-1 fw-bold">Ventas por papelito</h5>
-                            <p class="text-muted mb-0">Revisa montos, reventados y estado de sorteo en un solo lugar.</p>
-                        </div>
-                        <div class="d-flex flex-column flex-sm-row gap-2 w-100 w-lg-auto">
-                            <div class="input-group input-group-sm">
-                                <span class="input-group-text bg-white"><span class="material-icons" style="font-size:18px;">search</span></span>
-                                <input id="papelitoFilter" type="text" class="form-control" placeholder="Buscar por papelito o sorteo" />
-                            </div>
-                            <div class="form-check form-switch d-flex align-items-center m-0 px-2 border rounded">
-                                <input class="form-check-input me-2" type="checkbox" id="pendingOnly">
-                                <label class="form-check-label small text-nowrap" for="pendingOnly">Solo pendientes</label>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="d-flex flex-wrap gap-2 mb-3">
-                        <span class="badge rounded-pill text-bg-light border">Papelitos: @totalPapelitos</span>
-                        <span class="badge rounded-pill text-bg-light border">Monto: ₡ @totalMonto.ToString("N0")</span>
-                        <span class="badge rounded-pill text-bg-light border">Reventado: ₡ @totalReventado.ToString("N0")</span>
-                    </div>
-
                     <div class="table-responsive">
-                        <table class="table table-hover align-middle" id="papelitosTable">
+                        <table class="table table-hover align-middle">
                             <thead class="table-light">
                                 <tr>
                                     <th>Papelito</th>
-                                    <th>Sorteos</th>
-                                    <th>Creación</th>
                                     <th>Sorteo</th>
+                                    <th>Fecha de creación</th>
+                                    <th>Fecha de sorteo</th>
                                     <th class="text-end">Monto</th>
                                     <th class="text-end">Reventado</th>
                                     <th class="text-end">Total</th>
@@ -148,32 +125,11 @@
                                     total = monto + reventado;
                                     totales += total;
 
-                                    <tr data-paper-id="@item.Id" data-pending="@(item.DrawDate > DateTime.Now)">
+                                    <tr>
                                         <td class="fw-semibold">#@item.Id</td>
-                                        <td>
-                                            <div class="d-flex flex-wrap gap-1">
-                                                @foreach (var lot in (item.Lottery ?? string.Empty).Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                                                {
-                                                    <span class="badge text-bg-secondary-subtle border">@lot</span>
-                                                }
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <div class="small fw-semibold">@item.CreationDate.ToString("dd/MM/yyyy")</div>
-                                            <div class="text-muted small">@item.CreationDate.ToString("hh:mm tt")</div>
-                                        </td>
-                                        <td>
-                                            <div class="small fw-semibold">@item.DrawDate.ToString("dd/MM/yyyy")</div>
-                                            <div class="text-muted small">@item.DrawDate.ToString("hh:mm tt")</div>
-                                            @if (item.DrawDate > DateTime.Now)
-                                            {
-                                                <span class="badge rounded-pill text-bg-warning-subtle border mt-1">Pendiente</span>
-                                            }
-                                            else
-                                            {
-                                                <span class="badge rounded-pill text-bg-success-subtle border mt-1">Jugado</span>
-                                            }
-                                        </td>
+                                        <td><span class="badge bg-secondary">@item.Lottery</span></td>
+                                        <td>@item.CreationDate.ToString("g")</td>
+                                        <td>@item.DrawDate.ToString("g")</td>
                                         <td class="text-end">₡ @monto.ToString("N0")</td>
                                         <td class="text-end">₡ @reventado.ToString("N0")</td>
                                         <td class="text-end fw-bold">₡ @total.ToString("N0")</td>
@@ -217,9 +173,6 @@
                                 </tr>
                             </tfoot>
                         </table>
-                    </div>
-                    <div id="papelitosNoResults" class="alert alert-light border text-center mt-3 d-none mb-0">
-                        No hay resultados para el filtro aplicado.
                     </div>
                 </div>
             </div>
@@ -285,48 +238,6 @@ else
                 var id = $(this).data("id");
                 $("#delete-partial-" + id).toggle();
             });
-
-            function filterPapelitos() {
-                var query = ($("#papelitoFilter").val() || "").toLowerCase().trim();
-                var onlyPending = $("#pendingOnly").is(":checked");
-                var visibleRows = 0;
-
-                $("#papelitosTable tbody tr").not("[id^='delete-partial-']").each(function() {
-                    var row = $(this);
-                    var rowText = row.text().toLowerCase();
-                    var isPending = (row.data("pending") === true || row.data("pending") === "True");
-                    var matchQuery = !query || rowText.indexOf(query) >= 0;
-                    var matchPending = !onlyPending || isPending;
-                    var show = matchQuery && matchPending;
-
-                    row.toggle(show);
-                    var deleteRow = $("#delete-partial-" + row.data("paper-id"));
-                    if (!show) {
-                        deleteRow.hide();
-                    }
-
-                    if (show) {
-                        visibleRows++;
-                    }
-                });
-
-                $("#papelitosNoResults").toggleClass("d-none", visibleRows > 0);
-            }
-
-            $("#papelitoFilter").on("input", filterPapelitos);
-            $("#pendingOnly").on("change", filterPapelitos);
         });
     </script>
 }
-
-<style>
-    #papelitos-pane .table thead th {
-        white-space: nowrap;
-    }
-
-    #papelitos-pane .badge.text-bg-secondary-subtle,
-    #papelitos-pane .badge.text-bg-warning-subtle,
-    #papelitos-pane .badge.text-bg-success-subtle {
-        color: #212529;
-    }
-</style>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -8,9 +8,9 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/LaLlamaDelBosque.styles.css" asp-append-version="true" />
 </head>
-<body>
+<body class="app-body">
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-4 app-navbar">
             <div class="container-fluid">
                 <a class="navbar-brand nav-link" asp-area="" asp-controller="Home" asp-action="Index">La Llama Del Bosque</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
@@ -56,13 +56,13 @@
             </div>
         </nav>
     </header>
-    <div class="container">
-        <main role="main" class="pb-3">
+    <div class="container app-shell">
+        <main role="main" class="pb-3 app-main">
             @RenderBody()
         </main>
     </div>
 
-    <footer class="border-top footer text-muted">
+    <footer class="border-top footer text-muted app-footer">
         <div class="container navbar-text">
             &copy; @DateTime.Today.Year - La Llama Del Bosque
         </div>

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -32,3 +32,11 @@ Al crear o editar vistas:
 2. Priorizar Bootstrap + clases del sistema (`ds-*`) antes de crear estilos inline.
 3. Mantener tokens (`var(--*)`) para colores/radios/sombras.
 4. Evitar colores hardcodeados salvo casos excepcionales.
+
+## Guía de botones (estándar único)
+- `btn-primary`: acción principal.
+- `btn-secondary`: acción secundaria/cancelar.
+- `btn-danger`: acciones destructivas.
+- `btn-success`: acciones de confirmación puntual.
+- `btn-outline-*`: acciones complementarias.
+- `btn` sin variante se renderiza como botón neutro del sistema (fondo claro + borde suave), para mantener coherencia en botones heredados.

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,34 @@
+# Design System - La Llama Del Bosque
+
+## Objetivo
+Unificar el diseño visual en todas las pantallas con un estilo moderno, elegante y consistente.
+
+## Tokens globales
+Definidos en `wwwroot/css/site.css` dentro de `:root`:
+- **Colores de marca:** `--primary`, `--primary-strong`, `--secondary`.
+- **Colores de estado:** `--success`, `--warning`, `--danger`.
+- **Superficies:** `--background`, `--surface`, `--surface-soft`, `--layout`.
+- **Tipografía:** `Inter` para UI y `Playfair Display` para headings.
+- **Espaciado visual:** `--radius-*`, `--shadow-*`, `--border-color`.
+
+## Componentes base estandarizados
+- **Shell de app:** `app-body`, `app-shell`, `app-main`.
+- **Navegación:** `app-navbar`.
+- **Footer:** `app-footer`.
+- **Botones:** estilo consistente por `btn`, `btn-primary`, `btn-success`, `btn-danger`.
+- **Form controls:** `form-control`, `form-select`, `input-group-text` con focus homogéneo.
+- **Data display:** `card`, `table`, `badge`, `alert` con bordes y radios consistentes.
+
+## Utilidades de sistema
+Clases reutilizables para pantallas nuevas:
+- `ds-section-title`
+- `ds-kpi`
+- `ds-kpi-label`
+- `ds-kpi-value`
+
+## Regla de uso
+Al crear o editar vistas:
+1. Usar layout global (`_Layout.cshtml`) con `app-body`, `app-shell`, `app-main`.
+2. Priorizar Bootstrap + clases del sistema (`ds-*`) antes de crear estilos inline.
+3. Mantener tokens (`var(--*)`) para colores/radios/sombras.
+4. Evitar colores hardcodeados salvo casos excepcionales.

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -190,11 +190,25 @@ a:hover {
 .btn {
     border-radius: .65rem;
     font-weight: 600;
+    padding: .5rem .9rem;
+    border: 1px solid transparent;
     transition: all .2s ease;
 }
 
 .btn:hover {
     transform: translateY(-1px);
+}
+
+/* Botón base para botones que solo usan class="btn" */
+.btn:not(.btn-primary):not(.btn-secondary):not(.btn-success):not(.btn-danger):not(.btn-warning):not(.btn-info):not(.btn-light):not(.btn-dark):not(.btn-link):not(.btn-close):not(.btn-outline-primary):not(.btn-outline-secondary):not(.btn-outline-success):not(.btn-outline-danger):not(.btn-outline-warning):not(.btn-outline-info):not(.btn-outline-light):not(.btn-outline-dark) {
+    background-color: var(--surface);
+    border-color: var(--border-color);
+    color: var(--text-main);
+}
+
+.btn:not(.btn-primary):not(.btn-secondary):not(.btn-success):not(.btn-danger):not(.btn-warning):not(.btn-info):not(.btn-light):not(.btn-dark):not(.btn-link):not(.btn-close):not(.btn-outline-primary):not(.btn-outline-secondary):not(.btn-outline-success):not(.btn-outline-danger):not(.btn-outline-warning):not(.btn-outline-info):not(.btn-outline-light):not(.btn-outline-dark):hover {
+    border-color: color-mix(in srgb, var(--primary) 35%, #ffffff);
+    color: var(--primary-strong);
 }
 
 .btn-primary {
@@ -219,6 +233,22 @@ a:hover {
     background-color: var(--success);
     border-color: var(--success);
     color: #fff;
+}
+
+.btn-secondary {
+    background-color: #475569;
+    border-color: #475569;
+    color: #fff;
+}
+
+.btn-outline-primary,
+.btn-outline-secondary,
+.btn-outline-success,
+.btn-outline-danger,
+.btn-outline-warning,
+.btn-outline-info,
+.btn-outline-dark {
+    background-color: transparent;
 }
 
 .nav-pills .nav-link.active,

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,70 +1,236 @@
-/* Fuentes */
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Lora&display=swap');
+/* Tipografías */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap');
+
 :root {
-    --background: #e2e8f0;
-    --danger: #FF4136;
-    --layout: #EEF2FF;
-    --light: #FFFFFF;
-    --primary: #3B82F6;
-    --secondary: #2DCDDF;
-    --warning: #F6C324;
-    --success: #2B8A3E;
+    /* Paleta base */
+    --background: #f4f7fb;
+    --surface: #ffffff;
+    --surface-soft: #f8fafc;
+    --layout: #eef3ff;
+
+    /* Marca */
+    --primary: #2563eb;
+    --primary-strong: #1d4ed8;
+    --secondary: #0ea5a4;
+
+    /* Estado */
+    --success: #15803d;
+    --warning: #ca8a04;
+    --danger: #dc2626;
+
+    /* Texto */
+    --text-main: #0f172a;
+    --text-muted: #64748b;
+
+    /* Bordes + sombras */
+    --border-color: #dbe3ef;
+    --radius-sm: .5rem;
+    --radius-md: .9rem;
+    --radius-lg: 1.2rem;
+    --shadow-soft: 0 8px 30px rgba(15, 23, 42, .06);
+    --shadow-hover: 0 12px 36px rgba(37, 99, 235, .14);
 }
 
-
 html {
-  font-size: 14px;
+    font-size: 14px;
+    position: relative;
+    min-height: 100%;
 }
 
 @media (min-width: 768px) {
-  html {
-    font-size: 16px;
-  }
+    html {
+        font-size: 16px;
+    }
 }
 
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-    font-family: 'Montserrat', sans-serif;
-    background: var(--background);
+body.app-body {
+    font-family: 'Inter', sans-serif;
+    color: var(--text-main);
+    background:
+        radial-gradient(circle at 15% 10%, rgba(37, 99, 235, .08), transparent 32%),
+        radial-gradient(circle at 85% 15%, rgba(14, 165, 164, .08), transparent 30%),
+        var(--background);
     margin-bottom: 60px;
 }
 
-.navbar {
-    background: var(--layout);
+h1,
+h2,
+h3 {
+    font-family: 'Playfair Display', serif;
+    font-weight: 700;
+    letter-spacing: .2px;
+}
+
+h4,
+h5,
+h6 {
+    font-weight: 600;
+}
+
+/* Shell global */
+.app-shell {
+    max-width: 1320px;
+}
+
+.app-main {
+    background: color-mix(in srgb, var(--surface) 82%, transparent);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+    padding: 1.25rem;
+}
+
+@media (min-width: 992px) {
+    .app-main {
+        padding: 1.75rem;
+    }
+}
+
+/* Navbar + footer */
+.app-navbar {
+    background: color-mix(in srgb, var(--layout) 90%, #ffffff);
+    backdrop-filter: blur(8px);
+}
+
+a.navbar-brand {
+    white-space: normal;
+    text-align: center;
+    font-weight: 700;
+}
+
+.navbar .nav-link,
+.navbar .dropdown-item {
+    color: var(--text-main);
+}
+
+.navbar .nav-link:hover,
+.navbar .dropdown-item:hover {
+    color: var(--primary-strong);
+}
+
+.app-footer {
+    background-color: color-mix(in srgb, var(--layout) 88%, #ffffff);
 }
 
 .footer {
-    background-color: var(--layout);
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    white-space: nowrap;
+    line-height: 60px;
 }
 
-h1, h2 {
-    font-family: 'Lora', serif;
-    font-weight: 700;
-    margin: 1px;
+/* Elementos base */
+a {
+    color: var(--primary);
+    text-decoration-thickness: .08em;
+}
+
+a:hover {
+    color: var(--primary-strong);
+}
+
+.border-top {
+    border-top: 1px solid var(--border-color) !important;
+}
+
+.border-bottom {
+    border-bottom: 1px solid var(--border-color) !important;
+}
+
+.box-shadow {
+    box-shadow: var(--shadow-soft);
+}
+
+.card,
+.table,
+.alert,
+.list-group-item,
+.dropdown-menu,
+.modal-content {
+    border-color: var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.card {
+    box-shadow: var(--shadow-soft);
+}
+
+.table {
+    background-color: var(--surface);
+    overflow: hidden;
+}
+
+.table > :not(caption) > * > * {
+    padding: .75rem .8rem;
+}
+
+.table thead th {
+    font-size: .82rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--text-muted);
+}
+
+/* Formularios */
+.form-control,
+.form-select,
+.input-group-text {
+    border-radius: var(--radius-sm);
+    border-color: var(--border-color);
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: color-mix(in srgb, var(--primary) 45%, #ffffff);
+    box-shadow: 0 0 0 .2rem rgba(37, 99, 235, .14);
+}
+
+/* Botones */
+.btn {
+    border-radius: .65rem;
+    font-weight: 600;
+    transition: all .2s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
 }
 
 .btn-primary {
     background-color: var(--primary);
-    color: var(--light);
+    border-color: var(--primary);
+    color: #fff;
+}
+
+.btn-primary:hover {
+    background-color: var(--primary-strong);
+    border-color: var(--primary-strong);
+    box-shadow: var(--shadow-hover);
 }
 
 .btn-danger {
     background-color: var(--danger);
-    color: var(--light);
+    border-color: var(--danger);
+    color: #fff;
 }
 
 .btn-success {
     background-color: var(--success);
-    color: var(--light);
+    border-color: var(--success);
+    color: #fff;
 }
 
-.btn {
-    border-radius: .45rem;
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
+    color: #fff;
+    background-color: var(--primary);
+}
+
+/* Badges + iconografía */
+.badge {
+    border-radius: 999px;
+    font-weight: 600;
 }
 
 .btn-icon {
@@ -72,8 +238,8 @@ h1, h2 {
     font-size: 1.5rem;
     background-color: transparent;
     border: none;
-    color: #007bff;
-    transition: color 0.3s ease-in-out;
+    color: var(--primary);
+    transition: color .2s ease;
     height: 24px;
 }
 
@@ -119,17 +285,42 @@ span.text-bg-danger {
     color: var(--success);
 }
 
-.accordion-item {
-    border-radius: 0.25rem;
+/* Utilidades de Design System reutilizables */
+.ds-section-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    margin-bottom: 1rem;
 }
 
-.table {
-    background-color: white;
-    border-radius: 0.25rem;
+.ds-kpi {
+    background: var(--surface-soft);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: .8rem 1rem;
+}
+
+.ds-kpi-label {
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--text-muted);
+}
+
+.ds-kpi-value {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.accordion-item {
+    border-radius: var(--radius-sm);
 }
 
 .table-striped-columns td:not(:last-child) {
-    border-right: 1px solid #ddd;
+    border-right: 1px solid var(--border-color);
 }
 
 [id*="Partial"] {
@@ -138,13 +329,13 @@ span.text-bg-danger {
 
 .custom-tooltip .tooltip-inner {
     background-color: var(--secondary);
-    color: var(--light);
+    color: #fff;
 }
 
 .circle {
     width: 30px;
     height: 30px;
-    background: radial-gradient(at top left, var(--danger) 20%, #800000);
+    background: radial-gradient(at top left, color-mix(in srgb, var(--danger) 85%, #fff), #7f1d1d);
     color: white;
     border-radius: 50%;
     display: flex;
@@ -152,7 +343,7 @@ span.text-bg-danger {
     justify-content: center;
     font-weight: bold;
     font-size: 18px;
-    transition: transform 0.5s ease;
+    transition: transform .5s ease;
     transform-style: preserve-3d;
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y la navegación en la pestaña "Papelitos" para facilitar la revisión y el filtrado de ventas cuando hay muchos registros.
- Proveer controles rápidos (búsqueda y filtro) y resúmenes visuales para acelerar las tareas frecuentes de los operadores.

### Description
- Actualicé `Views/Lottery/Index.cshtml` para añadir un encabezado descriptivo, un campo de búsqueda (`#papelitoFilter`) y un switch `#pendingOnly` para mostrar solo ventas pendientes. 
- Añadí badges de resumen (conteo de papelitos, monto y reventado) y cambié la tabla para mostrar sorteos como badges, fechas formateadas y estado (Pendiente/Jugado). 
- Añadí atributos en cada fila (`data-paper-id` y `data-pending`), un bloque JS `filterPapelitos()` que filtra filas por texto y por estado pendiente y que oculta también el parcial de eliminación cuando la fila no está visible. 
- Incorporé un mensaje de estado `#papelitosNoResults` para cuando no haya coincidencias y ajustes CSS menores para mejorar la presentación de encabezados y badges.

### Testing
- Se intentó ejecutar `dotnet build` pero falló porque `dotnet` no está disponible en el entorno (`/bin/bash: dotnet: command not found`).
- No se ejecutaron pruebas automatizadas adicionales en este entorno debido a la falta del runtime de .NET.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d507d566a0833099d1410ff6908a1f)