### PR TITLE
Normalize and validate lottery number input; add UI preview and parsing improvements

### DIFF
--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -1,6 +1,7 @@
 ﻿using LaLlamaDelBosque.Models;
 using LaLlamaDelBosque.Utils;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace LaLlamaDelBosque.Controllers
 {
@@ -237,7 +238,20 @@ namespace LaLlamaDelBosque.Controllers
 				var amountParsed = double.TryParse(collection["amount"], out amount);
 				var bustedParsed = double.TryParse(collection["busted"], out busted);
 
-				var numberList = collection["value"].ToString().TrimEnd('+').Split('+');
+				var numberList = Regex.Split(collection["value"].ToString(), @"[+,\s]+")
+					.Select(number => number.Trim())
+					.Where(number => !string.IsNullOrWhiteSpace(number))
+					.SelectMany(number =>
+					{
+						if(Regex.IsMatch(number, @"^\d{3,}$") && number.Length % 2 == 0)
+						{
+							return Enumerable.Range(0, number.Length / 2)
+								.Select(index => number.Substring(index * 2, 2));
+						}
+
+						return new[] { number.Length == 1 ? number.PadLeft(2, '0') : number };
+					})
+					.ToList();
 
 				var paper = TempData.Get<Paper>("Paper") ?? new Paper();
 				var count = paper.Numbers.Max(p => p.Id) ?? 0;

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -195,24 +195,84 @@
             window.location.href = url;
         }
 
-        function setFormat(id, key) {
-            if (document.getElementById(id).value != "") {
-                if (key !== 8) {
-                    document.getElementById(id).addEventListener('input', function (e) {
-                        e.target.value = e.target.value.replace(/[^\dA-Z]/g, '').replace(/(.{2})/g, '$1+').trim();
-                    });
-                }
-                else {
-                    newText = document.getElementById(id).value.substring(0, document.getElementById(id).value.length - 1);
-                    document.getElementById(id).value = newText;
-                }
+        function splitNumberTokens(rawValue) {
+            return (rawValue || "")
+                .split(/[+,\s]+/)
+                .map(token => token.trim())
+                .filter(token => token.length > 0);
+        }
+
+        function normalizeNumberToken(token) {
+            if (/^\d$/.test(token)) {
+                return [token.padStart(2, '0')];
+            }
+
+            if (/^\d{3,}$/.test(token) && token.length % 2 === 0) {
+                return token.match(/.{1,2}/g) || [token];
+            }
+
+            return [token];
+        }
+
+        function validateNumberTokens(tokens) {
+            const invalidTokens = tokens.filter(token => !/^\d{1,2}$/.test(token));
+            return {
+                isValid: invalidTokens.length === 0,
+                invalidTokens: invalidTokens
+            };
+        }
+
+        function updateNumberInputUI(input, tokens, validation) {
+            const preview = document.getElementById('numberPreview');
+            const feedback = document.getElementById('numberFeedback');
+            const submitButton = document.getElementById('addNumberSubmit');
+
+            if (preview) {
+                preview.textContent = tokens.length > 0 ? `Se guardará como: ${tokens.join('+')}` : '';
+            }
+
+            if (feedback) {
+                feedback.textContent = validation.isValid
+                    ? ''
+                    : `Formato inválido en: ${validation.invalidTokens.join(', ')}. Solo se permiten números de 1 o 2 dígitos.`;
+            }
+
+            if (submitButton) {
+                submitButton.disabled = !validation.isValid || tokens.length === 0;
             }
         }
 
+        function formatNumberInput(input) {
+            const tokens = splitNumberTokens(input.value)
+                .flatMap(normalizeNumberToken);
+            const validation = validateNumberTokens(tokens);
+
+            input.value = tokens.join('+');
+            updateNumberInputUI(input, tokens, validation);
+        }
+
+        function normalizeNumberInput(input) {
+            formatNumberInput(input);
+        }
+
         $(document).ready(function () {
+            const numberInput = document.getElementById('number');
+            if (numberInput) {
+                formatNumberInput(numberInput);
+            }
+
             $('form').submit(function (e) {
                 var amount = parseFloat($('#Amount').val());
                 var busted = parseFloat($('#Busted').val());
+
+                if (numberInput) {
+                    formatNumberInput(numberInput);
+                    if (document.getElementById('addNumberSubmit')?.disabled) {
+                        numberInput.focus();
+                        e.preventDefault();
+                        return;
+                    }
+                }
 
                 if (busted > amount) {
                     $('#Busted').siblings('.text-danger').text('El campo no puede ser mayor que el Monto.');

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -25,13 +25,16 @@
         }
         <div class="form-group col-md-6">
             <label asp-for="Value" class="control-label">Números</label>
-            <input asp-for="Value" id="number" class="form-control" onkeydown="setFormat('number',event.keyCode)" />
+            <input asp-for="Value" id="number" class="form-control" oninput="formatNumberInput(this)" onblur="normalizeNumberInput(this)" placeholder="Ej: 11+00, 11,0 o 1100" autocomplete="off" inputmode="numeric" />
+            <small class="form-text text-muted">Puede separar con <strong>+</strong>, coma o espacio. Si escribe <strong>1100</strong>, se separa como <strong>11+00</strong>. Los números de 1 dígito se convierten a 2 dígitos (ej: 0 → 00).</small>
+            <small id="numberPreview" class="form-text text-primary fw-bold"></small>
+            <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
         </div>
         <div class="form-group col-md-1">
             <label class="control-label">&nbsp;</label>
             <!-- Add -->
-            <input type="submit" value="Agregar" class="btn btn-primary" />
+            <input type="submit" id="addNumberSubmit" value="Agregar" class="btn btn-primary" />
         </div>
     </div>
 </form>


### PR DESCRIPTION
### Motivation
- Improve robustness of number entry by allowing multiple separators (plus, comma, space) and padding single-digit numbers to two digits. 
- Support compact multi-number tokens (e.g. `1100`) by splitting into two-digit groups server- and client-side. 
- Provide immediate UI feedback and prevent submitting malformed numbers from the Create/Add form. 

### Description
- Enhanced server-side parsing in `LotteryController.Add` to use `Regex.Split` and expanded token handling that pads single-digit tokens and splits even-length long numeric tokens into 2-digit groups, and added `using System.Text.RegularExpressions;`. 
- Replaced the older inline formatter in `Views/Lottery/Create.cshtml` with modular JavaScript functions: `splitNumberTokens`, `normalizeNumberToken`, `validateNumberTokens`, `formatNumberInput`, and `normalizeNumberInput`, and wired formatting on input, blur and form submit to prevent invalid submissions. 
- Updated `Views/Lottery/_Add.cshtml` to attach the client-side formatter via `oninput`/`onblur`, added `placeholder`, `inputmode=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a70a3dbc8330a3ec2f6d7deb73fa)