### PR TITLE
Add number-selection palette and centralize lottery number parsing

### DIFF
--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -7,6 +7,10 @@ namespace LaLlamaDelBosque.Controllers
 {
 	public class LotteryController: Controller
 	{
+		private static readonly Regex NumberTokenPattern = new(@"^\d{1,2}$", RegexOptions.Compiled);
+		private static readonly Regex CompactNumberPattern = new(@"^\d{3,}$", RegexOptions.Compiled);
+		private static readonly Regex NumberSplitPattern = new(@"[+,\s]+", RegexOptions.Compiled);
+
 		private List<Lottery> _lotteries;
 		private readonly List<Paper> _papers;
 		private readonly List<Credit> _credits;
@@ -238,20 +242,11 @@ namespace LaLlamaDelBosque.Controllers
 				var amountParsed = double.TryParse(collection["amount"], out amount);
 				var bustedParsed = double.TryParse(collection["busted"], out busted);
 
-				var numberList = Regex.Split(collection["value"].ToString(), @"[+,\s]+")
-					.Select(number => number.Trim())
-					.Where(number => !string.IsNullOrWhiteSpace(number))
-					.SelectMany(number =>
-					{
-						if(Regex.IsMatch(number, @"^\d{3,}$") && number.Length % 2 == 0)
-						{
-							return Enumerable.Range(0, number.Length / 2)
-								.Select(index => number.Substring(index * 2, 2));
-						}
-
-						return new[] { number.Length == 1 ? number.PadLeft(2, '0') : number };
-					})
-					.ToList();
+				var numberList = ParseNumberTokens(collection["value"].ToString());
+				if(!numberList.Any())
+				{
+					return RedirectToAction(nameof(Create), new { cc = true });
+				}
 
 				var paper = TempData.Get<Paper>("Paper") ?? new Paper();
 				var count = paper.Numbers.Max(p => p.Id) ?? 0;
@@ -284,6 +279,32 @@ namespace LaLlamaDelBosque.Controllers
 			{
 				return RedirectToAction("Error", "Home", new { errorMsg = ex.Message });
 			}
+		}
+
+		private static List<string> ParseNumberTokens(string rawValue)
+		{
+			return NumberSplitPattern.Split(rawValue ?? string.Empty)
+				.Select(number => number.Trim())
+				.Where(number => !string.IsNullOrWhiteSpace(number))
+				.SelectMany(NormalizeNumberToken)
+				.Where(number => NumberTokenPattern.IsMatch(number))
+				.ToList();
+		}
+
+		private static IEnumerable<string> NormalizeNumberToken(string token)
+		{
+			if(token.Length == 1)
+			{
+				return new[] { token.PadLeft(2, '0') };
+			}
+
+			if(CompactNumberPattern.IsMatch(token) && token.Length % 2 == 0)
+			{
+				return Enumerable.Range(0, token.Length / 2)
+					.Select(index => token.Substring(index * 2, 2));
+			}
+
+			return new[] { token };
 		}
 
 		// POST: LotteryController/Remove/5

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -195,83 +195,104 @@
             window.location.href = url;
         }
 
-        function splitNumberTokens(rawValue) {
-            return (rawValue || "")
-                .split(/[+,\s]+/)
-                .map(token => token.trim())
-                .filter(token => token.length > 0);
+        let selectedNumbers = [];
+
+        function padNumber(value) {
+            return value.toString().padStart(2, "0");
         }
 
-        function normalizeNumberToken(token) {
-            if (/^\d$/.test(token)) {
-                return [token.padStart(2, '0')];
-            }
+        function renderSelectedNumbers() {
+            const hiddenInput = document.getElementById("number");
+            const container = document.getElementById("selectedNumbersContainer");
+            const feedback = document.getElementById("numberFeedback");
+            const submitButton = document.getElementById("addNumberSubmit");
+            if (!hiddenInput || !container) return;
 
-            if (/^\d{3,}$/.test(token) && token.length % 2 === 0) {
-                return token.match(/.{1,2}/g) || [token];
-            }
+            hiddenInput.value = selectedNumbers.join("+");
+            container.innerHTML = "";
 
-            return [token];
+            selectedNumbers.forEach(number => {
+                const chip = document.createElement("button");
+                chip.type = "button";
+                chip.className = "btn btn-sm btn-primary";
+                chip.textContent = `${number} ×`;
+                chip.onclick = function () {
+                    selectedNumbers = selectedNumbers.filter(x => x !== number);
+                    syncNumberPalette();
+                    renderSelectedNumbers();
+                };
+                container.appendChild(chip);
+            });
+
+            const hasSelection = selectedNumbers.length > 0;
+            if (feedback) feedback.textContent = hasSelection ? "" : "Selecciona al menos un número.";
+            if (submitButton) submitButton.disabled = !hasSelection;
         }
 
-        function validateNumberTokens(tokens) {
-            const invalidTokens = tokens.filter(token => !/^\d{1,2}$/.test(token));
-            return {
-                isValid: invalidTokens.length === 0,
-                invalidTokens: invalidTokens
-            };
+        function syncNumberPalette() {
+            const buttons = document.querySelectorAll(".number-cell");
+            buttons.forEach(btn => {
+                const value = btn.dataset.value;
+                btn.classList.toggle("btn-success", selectedNumbers.includes(value));
+                btn.classList.toggle("btn-outline-secondary", !selectedNumbers.includes(value));
+            });
         }
 
-        function updateNumberInputUI(input, tokens, validation) {
-            const preview = document.getElementById('numberPreview');
-            const feedback = document.getElementById('numberFeedback');
-            const submitButton = document.getElementById('addNumberSubmit');
-
-            if (preview) {
-                preview.textContent = tokens.length > 0 ? `Se guardará como: ${tokens.join('+')}` : '';
+        function toggleNumberSelection(value) {
+            if (selectedNumbers.includes(value)) {
+                selectedNumbers = selectedNumbers.filter(x => x !== value);
+            } else {
+                selectedNumbers.push(value);
+                selectedNumbers.sort();
             }
-
-            if (feedback) {
-                feedback.textContent = validation.isValid
-                    ? ''
-                    : `Formato inválido en: ${validation.invalidTokens.join(', ')}. Solo se permiten números de 1 o 2 dígitos.`;
-            }
-
-            if (submitButton) {
-                submitButton.disabled = !validation.isValid || tokens.length === 0;
-            }
+            syncNumberPalette();
+            renderSelectedNumbers();
         }
 
-        function formatNumberInput(input) {
-            const tokens = splitNumberTokens(input.value)
-                .flatMap(normalizeNumberToken);
-            const validation = validateNumberTokens(tokens);
-
-            input.value = tokens.join('+');
-            updateNumberInputUI(input, tokens, validation);
+        function clearSelectedNumbers() {
+            selectedNumbers = [];
+            syncNumberPalette();
+            renderSelectedNumbers();
         }
 
-        function normalizeNumberInput(input) {
-            formatNumberInput(input);
+        function toggleNumberPalette() {
+            const palette = document.getElementById("numberPalette");
+            if (!palette) return;
+            palette.style.display = palette.style.display === "none" ? "block" : "none";
+        }
+
+        function buildNumberGrid() {
+            const grid = document.getElementById("numberGrid");
+            if (!grid) return;
+            grid.innerHTML = "";
+            for (let i = 0; i < 100; i++) {
+                const value = padNumber(i);
+                const button = document.createElement("button");
+                button.type = "button";
+                button.dataset.value = value;
+                button.className = "btn btn-sm btn-outline-secondary number-cell";
+                button.textContent = value;
+                button.style.minWidth = "48px";
+                button.onclick = function () { toggleNumberSelection(value); };
+                grid.appendChild(button);
+            }
         }
 
         $(document).ready(function () {
             const numberInput = document.getElementById('number');
             if (numberInput) {
-                formatNumberInput(numberInput);
+                buildNumberGrid();
+                renderSelectedNumbers();
             }
 
             $('form').submit(function (e) {
                 var amount = parseFloat($('#Amount').val());
                 var busted = parseFloat($('#Busted').val());
 
-                if (numberInput) {
-                    formatNumberInput(numberInput);
-                    if (document.getElementById('addNumberSubmit')?.disabled) {
-                        numberInput.focus();
-                        e.preventDefault();
-                        return;
-                    }
+                if (numberInput && document.getElementById('addNumberSubmit')?.disabled) {
+                    document.getElementById("numberPalette")?.scrollIntoView({ behavior: "smooth", block: "center" });
+                    e.preventDefault();
+                    return;
                 }
 
                 if (busted > amount) {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -206,6 +206,7 @@
             const container = document.getElementById("selectedNumbersContainer");
             const feedback = document.getElementById("numberFeedback");
             const submitButton = document.getElementById("addNumberSubmit");
+            const placeholder = document.getElementById("numberPlaceholder");
             if (!hiddenInput || !container) return;
 
             hiddenInput.value = selectedNumbers.join("+");
@@ -225,6 +226,9 @@
             });
 
             const hasSelection = selectedNumbers.length > 0;
+            if (placeholder) {
+                placeholder.style.display = hasSelection ? "none" : "inline";
+            }
             if (feedback) feedback.textContent = hasSelection ? "" : "Selecciona al menos un número.";
             if (submitButton) submitButton.disabled = !hasSelection;
         }
@@ -253,6 +257,78 @@
             selectedNumbers = [];
             syncNumberPalette();
             renderSelectedNumbers();
+        }
+
+        function addUniqueValues(values) {
+            const union = new Set(selectedNumbers);
+            values.forEach(v => union.add(v));
+            selectedNumbers = Array.from(union).sort();
+            syncNumberPalette();
+            renderSelectedNumbers();
+        }
+
+        function selectRange() {
+            const startInput = document.getElementById("rangeStart");
+            const endInput = document.getElementById("rangeEnd");
+            const feedback = document.getElementById("numberFeedback");
+            if (!startInput || !endInput) return;
+
+            const start = parseInt(startInput.value, 10);
+            const end = parseInt(endInput.value, 10);
+
+            if (Number.isNaN(start) || Number.isNaN(end) || start < 0 || end > 99 || start > end) {
+                if (feedback) feedback.textContent = "Rango inválido. Usa valores entre 0 y 99, con inicio <= fin.";
+                return;
+            }
+
+            const values = [];
+            for (let i = start; i <= end; i++) values.push(padNumber(i));
+            addUniqueValues(values);
+        }
+
+        function isPrime(number) {
+            if (number < 2) return false;
+            for (let i = 2; i <= Math.sqrt(number); i++) {
+                if (number % i === 0) return false;
+            }
+            return true;
+        }
+
+        function selectByRule(rule, digit = null) {
+            const values = [];
+            for (let i = 0; i < 100; i++) {
+                const value = padNumber(i);
+                if (rule === "even" && i % 2 === 0) values.push(value);
+                if (rule === "odd" && i % 2 !== 0) values.push(value);
+                if (rule === "prime" && isPrime(i)) values.push(value);
+                if (rule === "startsWith" && value.startsWith(String(digit))) values.push(value);
+                if (rule === "endsWith" && value.endsWith(String(digit))) values.push(value);
+            }
+            addUniqueValues(values);
+        }
+
+        function applyStartsWithDigit() {
+            const input = document.getElementById("startsWithDigit");
+            const feedback = document.getElementById("numberFeedback");
+            if (!input) return;
+            const digit = parseInt(input.value, 10);
+            if (Number.isNaN(digit) || digit < 0 || digit > 9) {
+                if (feedback) feedback.textContent = "Para 'Inician en', usa un dígito de 0 a 9.";
+                return;
+            }
+            selectByRule("startsWith", digit);
+        }
+
+        function applyEndsWithDigit() {
+            const input = document.getElementById("endsWithDigit");
+            const feedback = document.getElementById("numberFeedback");
+            if (!input) return;
+            const digit = parseInt(input.value, 10);
+            if (Number.isNaN(digit) || digit < 0 || digit > 9) {
+                if (feedback) feedback.textContent = "Para 'Terminan en', usa un dígito de 0 a 9.";
+                return;
+            }
+            selectByRule("endsWith", digit);
         }
 
         function toggleNumberPalette() {

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -26,8 +26,11 @@
         <div class="form-group col-md-6">
             <label asp-for="Value" class="control-label">Números</label>
             <input asp-for="Value" id="number" type="hidden" />
-            <div class="d-flex flex-wrap gap-1 mb-2" id="selectedNumbersContainer"></div>
-            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones. No hay escritura manual para evitar errores.</small>
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm" id="selectedNumbersInputLike">
+                <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
+                <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+            </div>
+            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones o aplica reglas rápidas.</small>
             <div class="d-flex align-items-center gap-2 mb-2">
                 <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleNumberPalette()">
                     Mostrar/Ocultar selector
@@ -36,7 +39,46 @@
                     Limpiar selección
                 </button>
             </div>
-            <div id="numberPalette" class="border rounded p-2" style="max-height: 240px; overflow-y: auto;">
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm">
+                <div class="row g-2 align-items-end">
+                    <div class="col-md-4">
+                        <label class="form-label mb-1">Rango consecutivo</label>
+                        <div class="input-group input-group-sm">
+                            <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
+                            <span class="input-group-text">a</span>
+                            <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
+                            <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
+                        </div>
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label mb-1">Reglas rápidas</label>
+                        <div class="d-flex flex-wrap gap-1">
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('startsWith', 0)">Inician en 0</button>
+                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('endsWith', 0)">Terminan en 0</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="row g-2 mt-1">
+                    <div class="col-md-6">
+                        <label class="form-label mb-1">Inician en</label>
+                        <div class="input-group input-group-sm">
+                            <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                            <button type="button" class="btn btn-outline-secondary" onclick="applyStartsWithDigit()">Aplicar</button>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label mb-1">Terminan en</label>
+                        <div class="input-group input-group-sm">
+                            <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                            <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="numberPalette" class="border rounded bg-white p-2 shadow-sm" style="max-height: 240px; overflow-y: auto;">
                 <div id="numberGrid" class="d-flex flex-wrap gap-1"></div>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -30,7 +30,7 @@
                 <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
                 <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
             </div>
-            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones o aplica reglas rápidas.</small>
+            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones o usa una regla rápida.</small>
             <div class="d-flex align-items-center gap-2 mb-2">
                 <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleNumberPalette()">
                     Mostrar/Ocultar selector
@@ -41,7 +41,7 @@
             </div>
             <div class="border rounded bg-white p-2 mb-2 shadow-sm">
                 <div class="row g-2 align-items-end">
-                    <div class="col-md-4">
+                    <div class="col-md-5">
                         <label class="form-label mb-1">Rango consecutivo</label>
                         <div class="input-group input-group-sm">
                             <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
@@ -50,14 +50,12 @@
                             <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
                         </div>
                     </div>
-                    <div class="col-md-8">
+                    <div class="col-md-7">
                         <label class="form-label mb-1">Reglas rápidas</label>
                         <div class="d-flex flex-wrap gap-1">
                             <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
                             <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
                             <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('startsWith', 0)">Inician en 0</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('endsWith', 0)">Terminan en 0</button>
                         </div>
                     </div>
                 </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -25,9 +25,20 @@
         }
         <div class="form-group col-md-6">
             <label asp-for="Value" class="control-label">Números</label>
-            <input asp-for="Value" id="number" class="form-control" oninput="formatNumberInput(this)" onblur="normalizeNumberInput(this)" placeholder="Ej: 11+00, 11,0 o 1100" autocomplete="off" inputmode="numeric" />
-            <small class="form-text text-muted">Puede separar con <strong>+</strong>, coma o espacio. Si escribe <strong>1100</strong>, se separa como <strong>11+00</strong>. Los números de 1 dígito se convierten a 2 dígitos (ej: 0 → 00).</small>
-            <small id="numberPreview" class="form-text text-primary fw-bold"></small>
+            <input asp-for="Value" id="number" type="hidden" />
+            <div class="d-flex flex-wrap gap-1 mb-2" id="selectedNumbersContainer"></div>
+            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones. No hay escritura manual para evitar errores.</small>
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleNumberPalette()">
+                    Mostrar/Ocultar selector
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">
+                    Limpiar selección
+                </button>
+            </div>
+            <div id="numberPalette" class="border rounded p-2" style="max-height: 240px; overflow-y: auto;">
+                <div id="numberGrid" class="d-flex flex-wrap gap-1"></div>
+            </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
         </div>


### PR DESCRIPTION
### Motivation
- Replace fragile free-text number entry with a controlled selector to reduce user errors and simplify validation.
- Centralize and harden number token parsing on the server to support compact tokens (e.g. `1100` -> `11+00`) and consistent normalization.
- Improve UX by showing selected numbers as chips, disabling submit when no numbers selected, and toggling a palette for quick selection.

### Description
- Added compiled regex constants and two parsing helpers `ParseNumberTokens` and `NormalizeNumberToken` to `LotteryController` and switched the `Add` action to use them, returning to `Create` with `cc=true` when no numbers are provided.
- Replaced client-side free-text parsing in `Views/Lottery/Create.cshtml` with a number-palette UI and JS functions including `buildNumberGrid`, `renderSelectedNumbers`, `toggleNumberSelection`, `clearSelectedNumbers`, `syncNumberPalette`, and `padNumber`, and removed the old tokenization/validation functions.
- Updated `Views/Lottery/_Add.cshtml` to use a hidden `#number` input plus `#selectedNumbersContainer`, a toggleable `#numberPalette` grid, and control buttons instead of a manual input field, and wired up submit disabling/scroll behavior.

### Testing
- Built the solution with `dotnet build` and executed the test suite with `dotnet test`, and all automated tests passed.
- Performed automated project startup validation to ensure the `Create` view and `Add` action compile and render without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b9130ef083309cc97be6b5b420d4)