### PR TITLE
Refactor: usar utilidades de moneda en vistas y centralizar alerta de límite de crédito

### DIFF
--- a/Controllers/CreditController.cs
+++ b/Controllers/CreditController.cs
@@ -180,9 +180,7 @@ namespace LaLlamaDelBosque.Controllers
                             && previousTotal <= credit.Client.Limit.Value
                             && credit.CreditSummary.Total > credit.Client.Limit.Value)
                         {
-                            TempData["LimitExceededClientName"] = credit.Client.Name;
-                            TempData["LimitExceededClientTotal"] = credit.CreditSummary.Total.ToString("N0");
-                            TempData["LimitExceededClientLimit"] = credit.Client.Limit.Value.ToString("N0");
+                            SetLimitExceededTempData(credit);
                         }
                     }
 
@@ -252,9 +250,7 @@ namespace LaLlamaDelBosque.Controllers
                     && previousTotal <= credit.Client.Limit.Value
                     && credit.CreditSummary.Total > credit.Client.Limit.Value)
                 {
-                    TempData["LimitExceededClientName"] = credit.Client.Name;
-                    TempData["LimitExceededClientTotal"] = credit.CreditSummary.Total.ToString("N0");
-                    TempData["LimitExceededClientLimit"] = credit.Client.Limit.Value.ToString("N0");
+                    SetLimitExceededTempData(credit);
                 }
 
                 SetCredits(_credits);
@@ -343,6 +339,13 @@ namespace LaLlamaDelBosque.Controllers
                 text += $"✅ {credit.Client.Name.ToUpper()}: *₡ {credit.CreditSummary.Total}*. ";
             }
             return text;
+        }
+
+        private void SetLimitExceededTempData(Credit credit)
+        {
+            TempData["LimitExceededClientName"] = credit.Client.Name;
+            TempData["LimitExceededClientTotal"] = credit.CreditSummary.Total.ToCRC();
+            TempData["LimitExceededClientLimit"] = credit.Client.Limit?.ToCRC();
         }
     }
 }

--- a/Views/Credit/Index.cshtml
+++ b/Views/Credit/Index.cshtml
@@ -233,7 +233,7 @@
                 </div>
                 <div class="modal-body">
                     <p class="mb-2">El cliente <strong>@ViewBag.LimitExceededClientName</strong> acaba de exceder su límite de crédito.</p>
-                    <p class="mb-0 text-muted">Saldo actual: ₡ @ViewBag.LimitExceededClientTotal · Límite: ₡ @ViewBag.LimitExceededClientLimit</p>
+                    <p class="mb-0 text-muted">Saldo actual: @ViewBag.LimitExceededClientTotal · Límite: @ViewBag.LimitExceededClientLimit</p>
                 </div>
             </div>
         </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -43,7 +43,7 @@
             <div class="dashboard-highlight card border-0 h-100">
                 <div class="card-body">
                     <small class="text-uppercase text-muted">Venta total hoy</small>
-                    <h2 class="fw-bold text-primary mt-2 mb-1">₡ @Model.Lottery.Total</h2>
+                    <h2 class="fw-bold text-primary mt-2 mb-1">@Model.Lottery.Total.ToCRC()</h2>
                     <p class="text-muted small mb-0">Incluye monto base y reventado.</p>
                     <hr>
                     <div class="d-flex justify-content-between small text-muted">
@@ -78,7 +78,7 @@
                     <div class="d-flex justify-content-between align-items-start">
                         <div>
                             <small class="text-muted">Por cobrar</small>
-                            <h3 class="fw-bold mb-1">₡ @Model.Credit.Receivable</h3>
+                            <h3 class="fw-bold mb-1">@Model.Credit.Receivable.ToCRC()</h3>
                             <p class="text-muted small mb-0">Saldo pendiente acumulado</p>
                         </div>
                         <span class="kpi-icon bg-warning-subtle text-warning"><span class="material-icons">account_balance_wallet</span></span>
@@ -92,7 +92,7 @@
                     <div class="d-flex justify-content-between align-items-start">
                         <div>
                             <small class="text-muted">Abonos del día</small>
-                            <h3 class="fw-bold mb-1">₡ @Model.Credit.Received</h3>
+                            <h3 class="fw-bold mb-1">@Model.Credit.Received.ToCRC()</h3>
                             <p class="text-muted small mb-0">Pagos recibidos hoy</p>
                         </div>
                         <span class="kpi-icon bg-success-subtle text-success"><span class="material-icons">trending_up</span></span>
@@ -114,7 +114,7 @@
                         {
                             <li class="list-group-item d-flex justify-content-between px-0">
                                 <span>@item.Name</span>
-                                <strong>₡ @item.Amount</strong>
+                                <strong>@item.Amount.ToCRC()</strong>
                             </li>
                         }
                     </ul>
@@ -130,7 +130,7 @@
                         {
                             <li class="list-group-item d-flex justify-content-between px-0">
                                 <span>@item.Name</span>
-                                <strong>₡ @item.Amount</strong>
+                                <strong>@item.Amount.ToCRC()</strong>
                             </li>
                         }
                     </ul>
@@ -146,7 +146,7 @@
                         {
                             <li class="list-group-item d-flex justify-content-between px-0">
                                 <span>@item.Name</span>
-                                <strong>₡ @item.Amount</strong>
+                                <strong>@item.Amount.ToCRC()</strong>
                             </li>
                         }
                     </ul>
@@ -160,9 +160,9 @@
     <h5 class="fw-bold mb-3">Ventas por sorteo (hoy)</h5>
     <div class="row g-3">
         <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center"><div class="card-body"><small class="text-muted">Papelitos</small><h4 class="fw-bold">@Model.Lottery.Papers</h4></div></div></div>
-        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center"><div class="card-body"><small class="text-muted">Monto</small><h4 class="fw-bold">₡ @Model.Lottery.TotalAmount</h4></div></div></div>
-        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center"><div class="card-body"><small class="text-muted">Reventado</small><h4 class="fw-bold">₡ @Model.Lottery.TotalBusted</h4></div></div></div>
-        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center border-primary-subtle"><div class="card-body"><small class="text-muted">Total</small><h4 class="fw-bold text-primary">₡ @Model.Lottery.Total</h4></div></div></div>
+        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center"><div class="card-body"><small class="text-muted">Monto</small><h4 class="fw-bold">@Model.Lottery.TotalAmount.ToCRC()</h4></div></div></div>
+        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center"><div class="card-body"><small class="text-muted">Reventado</small><h4 class="fw-bold">@Model.Lottery.TotalBusted.ToCRC()</h4></div></div></div>
+        <div class="col-6 col-lg-3"><div class="card h-100 dashboard-kpi-modern text-center border-primary-subtle"><div class="card-body"><small class="text-muted">Total</small><h4 class="fw-bold text-primary">@Model.Lottery.Total.ToCRC()</h4></div></div></div>
     </div>
 </section>
 

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -147,8 +147,8 @@
                                         <tr>
                                             <td></td>
                                             <td class="fw-semibold">@item.Value</td>
-                                            <td>₡ @item.Amount.ToString("N0")</td>
-                                            <td>₡ @item.Busted.ToString("N0")</td>
+                                            <td>@item.Amount.ToCRC()</td>
+                                            <td>@item.Busted.ToCRC()</td>
                                             <td>
                                                 <!-- Remove -->
                                                 <button type="button" class="btn" onclick="showPartial('removePartial-@Model.Id-@item.Id')">
@@ -173,11 +173,11 @@
                 <div class="card text-white border-0 shadow-sm" style="background: linear-gradient(135deg, #3B82F6, #64b5f6);">
                     <div class="card-body">
                         <h2 class="card-title">Resumen</h2>
-                        <p class="card-text mb-1">Monto Total: ₡ @Model.Numbers.Sum(x => x.Amount).ToString("N0")</p>
-                        <p class="card-text">Reventado Total: ₡ @Model.Numbers.Sum(x => x.Busted).ToString("N0")</p>
+                        <p class="card-text mb-1">Monto Total: @Model.Numbers.Sum(x => x.Amount).ToCRC()</p>
+                        <p class="card-text">Reventado Total: @Model.Numbers.Sum(x => x.Busted).ToCRC()</p>
                         <hr>
-                        <p class="card-text mb-1" style="font-weight: bold; font-size: 1rem;">Total Papelito: ₡ @subsum.ToString("N0")</p>
-                        <p class="card-text mb-0" style="font-weight: bold; font-size: 1.2rem;">Total General: ₡ @sum.ToString("N0")</p>
+                        <p class="card-text mb-1" style="font-weight: bold; font-size: 1rem;">Total Papelito: @subsum.ToCRC()</p>
+                        <p class="card-text mb-0" style="font-weight: bold; font-size: 1.2rem;">Total General: @sum.ToCRC()</p>
                     </div>
                 </div>
 

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using LaLlamaDelBosque
 @using LaLlamaDelBosque.Models
+@using LaLlamaDelBosque.Utils
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
### Motivation
- Unificar y reutilizar el formateo de montos en toda la aplicación usando las utilidades ya existentes para evitar duplicación de presentación.
- Centralizar la preparación de `TempData` para la alerta de límite excedido y evitar repetir lógica en el controlador.
- Asegurar que las vistas consuman valores ya formateados por el controlador cuando corresponda para mantener consistencia en la UI.

### Description
- Agregado `@using LaLlamaDelBosque.Utils` en `Views/_ViewImports.cshtml` para habilitar extensiones de utilidad en las vistas.
- Reemplazado formateo manual (`₡ ...` y `ToString("N0")`) por la extensión `ToCRC()` en `Views/Home/Index.cshtml` y `Views/Lottery/Create.cshtml` para montos y totales.
- Añadido el método privado `SetLimitExceededTempData(Credit credit)` en `Controllers/CreditController.cs` y sustituida la lógica repetida de asignación de `TempData` por llamadas a este método desde `Add` y `Refresh`.
- Actualizado `Views/Credit/Index.cshtml` (modal de límite excedido) para mostrar los valores ya formateados por el controlador en lugar de anteponer manualmente el símbolo de moneda.

### Testing
- Intenté ejecutar `dotnet build` pero falló en este entorno con el error `/bin/bash: dotnet: command not found`, por lo que no se pudieron validar compilación/razor automáticamente aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a9f9c9488330944962d33e3133f2)