### PR TITLE
Mejora UX: pegado flexible de números y grilla de 10 columnas

### DIFF
--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -212,6 +212,7 @@
 
         let selectedNumbers = [];
         const appliedRuleValues = new Map();
+        let speechRecognitionInstance = null;
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -358,6 +359,59 @@
             const feedback = document.getElementById("numberFeedback");
             if (input) input.value = "";
             if (feedback) feedback.textContent = "";
+        }
+
+        function setVoiceInputState(isListening) {
+            const startButton = document.getElementById("voiceInputStart");
+            const stopButton = document.getElementById("voiceInputStop");
+            if (startButton) startButton.disabled = isListening;
+            if (stopButton) stopButton.disabled = !isListening;
+        }
+
+        function toggleVoiceInput(shouldStart) {
+            const feedback = document.getElementById("numberFeedback");
+            const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+            if (!SpeechRecognition) {
+                if (feedback) feedback.textContent = "Tu navegador no soporta dictado por voz. Puedes pegar una transcripción.";
+                return;
+            }
+
+            if (shouldStart) {
+                speechRecognitionInstance = new SpeechRecognition();
+                speechRecognitionInstance.lang = "es-ES";
+                speechRecognitionInstance.interimResults = false;
+                speechRecognitionInstance.continuous = false;
+
+                speechRecognitionInstance.onstart = function () {
+                    setVoiceInputState(true);
+                    if (feedback) feedback.textContent = "Escuchando... di los números como prefieras.";
+                };
+
+                speechRecognitionInstance.onresult = function (event) {
+                    const transcript = Array.from(event.results).map(r => r[0]?.transcript || "").join(" ").trim();
+                    const input = document.getElementById("bulkNumbersInput");
+                    if (input && transcript) {
+                        input.value = input.value ? `${input.value} ${transcript}` : transcript;
+                    }
+                    if (feedback) feedback.textContent = transcript ? "Audio transcrito. Ahora puedes Agregar o Reemplazar." : "No se detectó texto útil.";
+                };
+
+                speechRecognitionInstance.onerror = function () {
+                    if (feedback) feedback.textContent = "No se pudo transcribir el audio. Intenta de nuevo o pega texto.";
+                };
+
+                speechRecognitionInstance.onend = function () {
+                    setVoiceInputState(false);
+                };
+
+                speechRecognitionInstance.start();
+                return;
+            }
+
+            if (speechRecognitionInstance) {
+                speechRecognitionInstance.stop();
+            }
         }
 
         function selectRange() {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -212,6 +212,7 @@
 
         let selectedNumbers = [];
         const appliedRuleValues = new Map();
+        const appliedAdvancedValues = new Map();
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -272,7 +273,9 @@
         function clearSelectedNumbers() {
             selectedNumbers = [];
             appliedRuleValues.clear();
+            appliedAdvancedValues.clear();
             syncRuleButtons();
+            syncAdvancedButtons();
             syncNumberPalette();
             renderSelectedNumbers();
         }
@@ -360,7 +363,40 @@
             if (feedback) feedback.textContent = "";
         }
 
-        function selectRange() {
+        function syncAdvancedButtons() {
+            const entries = [
+                ["range", "rangeApplyButton"],
+                ["startsWith", "startsWithApplyButton"],
+                ["endsWith", "endsWithApplyButton"]
+            ];
+            entries.forEach(([key, buttonId]) => {
+                const button = document.getElementById(buttonId);
+                if (!button) return;
+                button.textContent = appliedAdvancedValues.has(key) ? "Quitar" : "Aplicar";
+            });
+        }
+
+        function applyOrToggleAdvanced(key, valuesFactory) {
+            const feedback = document.getElementById("numberFeedback");
+            const existing = appliedAdvancedValues.get(key);
+            const nextValues = valuesFactory();
+            if (!nextValues) return false;
+
+            if (existing && existing.signature === nextValues.signature) {
+                removeValues(existing.values);
+                appliedAdvancedValues.delete(key);
+                if (feedback) feedback.textContent = "Se quitó la selección aplicada.";
+            } else {
+                if (existing) removeValues(existing.values);
+                addUniqueValues(nextValues.values);
+                appliedAdvancedValues.set(key, nextValues);
+                if (feedback) feedback.textContent = "Selección aplicada.";
+            }
+            syncAdvancedButtons();
+            return true;
+        }
+
+        function applyOrToggleRange() {
             const startInput = document.getElementById("rangeStart");
             const endInput = document.getElementById("rangeEnd");
             const feedback = document.getElementById("numberFeedback");
@@ -376,7 +412,10 @@
 
             const values = [];
             for (let i = start; i <= end; i++) values.push(padNumber(i));
-            addUniqueValues(values);
+            applyOrToggleAdvanced("range", () => ({
+                signature: `${start}-${end}`,
+                values
+            }));
         }
 
         function isPrime(number) {
@@ -422,7 +461,7 @@
             syncRuleButtons();
         }
 
-        function applyStartsWithDigit() {
+        function applyOrToggleStartsWithDigit() {
             const input = document.getElementById("startsWithDigit");
             const feedback = document.getElementById("numberFeedback");
             if (!input) return;
@@ -431,10 +470,13 @@
                 if (feedback) feedback.textContent = "Para 'Inician en', usa un dígito de 0 a 9.";
                 return;
             }
-            addUniqueValues(getValuesByRule("startsWith", digit));
+            applyOrToggleAdvanced("startsWith", () => ({
+                signature: String(digit),
+                values: getValuesByRule("startsWith", digit)
+            }));
         }
 
-        function applyEndsWithDigit() {
+        function applyOrToggleEndsWithDigit() {
             const input = document.getElementById("endsWithDigit");
             const feedback = document.getElementById("numberFeedback");
             if (!input) return;
@@ -443,7 +485,10 @@
                 if (feedback) feedback.textContent = "Para 'Terminan en', usa un dígito de 0 a 9.";
                 return;
             }
-            addUniqueValues(getValuesByRule("endsWith", digit));
+            applyOrToggleAdvanced("endsWith", () => ({
+                signature: String(digit),
+                values: getValuesByRule("endsWith", digit)
+            }));
         }
 
         function pickRandomNumbers() {
@@ -464,10 +509,19 @@
             }
             selectedNumbers = pool.slice(0, count).sort();
             appliedRuleValues.clear();
+            appliedAdvancedValues.clear();
             syncRuleButtons();
+            syncAdvancedButtons();
             syncNumberPalette();
             renderSelectedNumbers();
             if (feedback) feedback.textContent = `Se seleccionaron ${count} número(s) al azar (reemplazando la selección actual).`;
+        }
+
+        function clearRandomCount() {
+            const countInput = document.getElementById("randomCount");
+            const feedback = document.getElementById("numberFeedback");
+            if (countInput) countInput.value = "";
+            if (feedback) feedback.textContent = "";
         }
 
         function toggleNumberPalette() {
@@ -498,6 +552,7 @@
                 buildNumberGrid();
                 renderSelectedNumbers();
                 syncRuleButtons();
+                syncAdvancedButtons();
             }
 
             $('#addNumberForm').submit(function (e) {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -462,8 +462,12 @@
                 const j = Math.floor(Math.random() * (i + 1));
                 [pool[i], pool[j]] = [pool[j], pool[i]];
             }
-            addUniqueValues(pool.slice(0, count));
-            if (feedback) feedback.textContent = `Se agregaron ${count} número(s) al azar.`;
+            selectedNumbers = pool.slice(0, count).sort();
+            appliedRuleValues.clear();
+            syncRuleButtons();
+            syncNumberPalette();
+            renderSelectedNumbers();
+            if (feedback) feedback.textContent = `Se seleccionaron ${count} número(s) al azar (reemplazando la selección actual).`;
         }
 
         function toggleNumberPalette() {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -282,6 +282,26 @@
             renderSelectedNumbers();
         }
 
+        function explodeDigitChunk(chunk) {
+            if (!chunk) return [];
+
+            if (chunk.length <= 2) {
+                const value = parseInt(chunk, 10);
+                return Number.isNaN(value) || value < 0 || value > 99 ? [] : [padNumber(value)];
+            }
+
+            const normalized = chunk.length % 2 === 0 ? chunk : `0${chunk}`;
+            const values = [];
+            for (let i = 0; i < normalized.length; i += 2) {
+                const pair = normalized.slice(i, i + 2);
+                const value = parseInt(pair, 10);
+                if (!Number.isNaN(value) && value >= 0 && value <= 99) {
+                    values.push(padNumber(value));
+                }
+            }
+            return values;
+        }
+
         function parseNumbersFromText(raw) {
             if (!raw) return [];
             const sanitized = raw.replace(/[\[\]\(\)"'“”‘’]/g, " ");
@@ -289,9 +309,7 @@
             const unique = new Set();
 
             chunks.forEach(chunk => {
-                const number = parseInt(chunk, 10);
-                if (Number.isNaN(number) || number < 0 || number > 99) return;
-                unique.add(padNumber(number));
+                explodeDigitChunk(chunk).forEach(value => unique.add(value));
             });
 
             return Array.from(unique).sort();
@@ -317,6 +335,12 @@
             }
 
             if (feedback) feedback.textContent = `${values.length} número(s) procesado(s) desde texto.`;
+
+            const modalElement = document.getElementById("pasteNumbersModal");
+            if (modalElement && window.bootstrap?.Modal) {
+                const instance = bootstrap.Modal.getInstance(modalElement);
+                if (instance) instance.hide();
+            }
         }
 
         function selectRange() {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -211,6 +211,7 @@
         }
 
         let selectedNumbers = [];
+        const appliedRuleValues = new Map();
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -270,6 +271,8 @@
 
         function clearSelectedNumbers() {
             selectedNumbers = [];
+            appliedRuleValues.clear();
+            syncRuleButtons();
             syncNumberPalette();
             renderSelectedNumbers();
         }
@@ -278,6 +281,13 @@
             const union = new Set(selectedNumbers);
             values.forEach(v => union.add(v));
             selectedNumbers = Array.from(union).sort();
+            syncNumberPalette();
+            renderSelectedNumbers();
+        }
+
+        function removeValues(values) {
+            const toRemove = new Set(values);
+            selectedNumbers = selectedNumbers.filter(v => !toRemove.has(v));
             syncNumberPalette();
             renderSelectedNumbers();
         }
@@ -377,7 +387,7 @@
             return true;
         }
 
-        function selectByRule(rule, digit = null) {
+        function getValuesByRule(rule, digit = null) {
             const values = [];
             for (let i = 0; i < 100; i++) {
                 const value = padNumber(i);
@@ -387,7 +397,29 @@
                 if (rule === "startsWith" && value.startsWith(String(digit))) values.push(value);
                 if (rule === "endsWith" && value.endsWith(String(digit))) values.push(value);
             }
-            addUniqueValues(values);
+            return values;
+        }
+
+        function syncRuleButtons() {
+            ["even", "odd", "prime"].forEach(rule => {
+                const button = document.getElementById(`rule-${rule}`);
+                if (!button) return;
+                const isActive = appliedRuleValues.has(rule);
+                button.classList.toggle("btn-primary", isActive);
+                button.classList.toggle("btn-outline-primary", !isActive);
+            });
+        }
+
+        function toggleRuleSelection(rule) {
+            if (appliedRuleValues.has(rule)) {
+                removeValues(appliedRuleValues.get(rule));
+                appliedRuleValues.delete(rule);
+            } else {
+                const values = getValuesByRule(rule);
+                addUniqueValues(values);
+                appliedRuleValues.set(rule, values);
+            }
+            syncRuleButtons();
         }
 
         function applyStartsWithDigit() {
@@ -399,7 +431,7 @@
                 if (feedback) feedback.textContent = "Para 'Inician en', usa un dígito de 0 a 9.";
                 return;
             }
-            selectByRule("startsWith", digit);
+            addUniqueValues(getValuesByRule("startsWith", digit));
         }
 
         function applyEndsWithDigit() {
@@ -411,7 +443,27 @@
                 if (feedback) feedback.textContent = "Para 'Terminan en', usa un dígito de 0 a 9.";
                 return;
             }
-            selectByRule("endsWith", digit);
+            addUniqueValues(getValuesByRule("endsWith", digit));
+        }
+
+        function pickRandomNumbers() {
+            const countInput = document.getElementById("randomCount");
+            const feedback = document.getElementById("numberFeedback");
+            const count = parseInt(countInput?.value || "", 10);
+
+            if (Number.isNaN(count) || count < 1 || count > 100) {
+                if (feedback) feedback.textContent = "Para A Gallo Tapado usa una cantidad entre 1 y 100.";
+                return;
+            }
+
+            const pool = [];
+            for (let i = 0; i < 100; i++) pool.push(padNumber(i));
+            for (let i = pool.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [pool[i], pool[j]] = [pool[j], pool[i]];
+            }
+            addUniqueValues(pool.slice(0, count));
+            if (feedback) feedback.textContent = `Se agregaron ${count} número(s) al azar.`;
         }
 
         function toggleNumberPalette() {
@@ -441,6 +493,7 @@
             if (numberInput) {
                 buildNumberGrid();
                 renderSelectedNumbers();
+                syncRuleButtons();
             }
 
             $('#addNumberForm').submit(function (e) {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -650,7 +650,10 @@
                         groups.push(digits.slice(i, i + 2));
                     }
                     const remainder = digits.slice(pairLimit);
-                    bulkInput.value = remainder ? `${groups.join("+")}${groups.length ? "+" : ""}${remainder}` : groups.join("+");
+                    if (remainder.length === 1) {
+                        groups.push(`0${remainder}`);
+                    }
+                    bulkInput.value = groups.join("+");
                 });
             }
 

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -239,7 +239,7 @@
                 const count = selectedNumberCounts.get(number) ?? 1;
                 const chip = document.createElement("button");
                 chip.type = "button";
-                chip.className = "btn btn-sm btn-primary";
+                chip.className = "numbers-chip";
                 chip.textContent = count > 1 ? `${number} x${count} ×` : `${number} ×`;
                 chip.onclick = function () {
                     const current = selectedNumberCounts.get(number) ?? 1;
@@ -267,6 +267,8 @@
             const buttons = document.querySelectorAll(".number-cell");
             buttons.forEach(btn => {
                 const value = btn.dataset.value;
+                const count = selectedNumberCounts.get(value) ?? 0;
+                btn.title = count > 0 ? `Cantidad: ${count}` : "Cantidad: 0";
                 btn.classList.toggle("btn-success", selectedNumbers.includes(value));
                 btn.classList.toggle("btn-outline-secondary", !selectedNumbers.includes(value));
             });

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -214,6 +214,8 @@
         const selectedNumberCounts = new Map();
         const appliedRuleValues = new Map();
         const appliedAdvancedValues = new Map();
+        let isDraggingNumbers = false;
+        let dragTouchedValues = new Set();
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -222,9 +224,11 @@
         function renderSelectedNumbers() {
             const hiddenInput = document.getElementById("number");
             const container = document.getElementById("selectedNumbersContainer");
+            const outsideContainer = document.getElementById("selectedNumbersContainerOutside");
             const feedback = document.getElementById("numberFeedback");
             const submitButton = document.getElementById("addNumberSubmit");
             const placeholder = document.getElementById("numberPlaceholder");
+            const outsidePlaceholder = document.getElementById("numberPlaceholderOutside");
             if (!hiddenInput || !container) return;
 
             const expanded = [];
@@ -234,6 +238,7 @@
             });
             hiddenInput.value = expanded.join("+");
             container.innerHTML = "";
+            if (outsideContainer) outsideContainer.innerHTML = "";
 
             selectedNumbers.forEach(number => {
                 const count = selectedNumberCounts.get(number) ?? 1;
@@ -253,14 +258,30 @@
                     renderSelectedNumbers();
                 };
                 container.appendChild(chip);
+                if (outsideContainer) {
+                    const outsideChip = chip.cloneNode(true);
+                    outsideChip.onclick = chip.onclick;
+                    outsideContainer.appendChild(outsideChip);
+                }
             });
 
             const hasSelection = selectedNumbers.length > 0;
             if (placeholder) {
                 placeholder.style.display = hasSelection ? "none" : "inline";
             }
+            if (outsidePlaceholder) {
+                outsidePlaceholder.style.display = hasSelection ? "none" : "inline";
+            }
             if (feedback) feedback.textContent = hasSelection ? "" : "Selecciona al menos un número.";
             if (submitButton) submitButton.disabled = !hasSelection;
+        }
+
+        function addOrIncrementSelection(value) {
+            if (!selectedNumbers.includes(value)) {
+                selectedNumbers.push(value);
+                selectedNumbers.sort();
+            }
+            selectedNumberCounts.set(value, (selectedNumberCounts.get(value) ?? 0) + 1);
         }
 
         function syncNumberPalette() {
@@ -275,13 +296,40 @@
         }
 
         function toggleNumberSelection(value) {
-            if (!selectedNumbers.includes(value)) {
-                selectedNumbers.push(value);
-                selectedNumbers.sort();
-            }
-            selectedNumberCounts.set(value, (selectedNumberCounts.get(value) ?? 0) + 1);
+            addOrIncrementSelection(value);
             syncNumberPalette();
             renderSelectedNumbers();
+        }
+
+        function applyNumberSelection(value) {
+            if (dragTouchedValues.has(value)) return;
+            dragTouchedValues.add(value);
+            addOrIncrementSelection(value);
+            syncNumberPalette();
+            renderSelectedNumbers();
+        }
+
+        function bindGridDragSelection() {
+            const grid = document.getElementById("numberGrid");
+            if (!grid) return;
+            grid.addEventListener("mousedown", function (e) {
+                const cell = e.target.closest(".number-cell");
+                if (!cell) return;
+                e.preventDefault();
+                isDraggingNumbers = true;
+                dragTouchedValues = new Set();
+                applyNumberSelection(cell.dataset.value);
+            });
+            grid.addEventListener("mouseover", function (e) {
+                if (!isDraggingNumbers) return;
+                const cell = e.target.closest(".number-cell");
+                if (!cell) return;
+                applyNumberSelection(cell.dataset.value);
+            });
+            document.addEventListener("mouseup", function () {
+                isDraggingNumbers = false;
+                dragTouchedValues = new Set();
+            });
         }
 
         function clearSelectedNumbers() {
@@ -582,6 +630,7 @@
             const numberInput = document.getElementById('number');
             if (numberInput) {
                 buildNumberGrid();
+                bindGridDragSelection();
                 renderSelectedNumbers();
                 syncRuleButtons();
                 syncAdvancedButtons();

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -644,12 +644,13 @@
             if (bulkInput) {
                 bulkInput.addEventListener("input", function () {
                     const digits = (bulkInput.value.match(/\d/g) || []).join("");
-                    const normalized = digits.length % 2 === 0 ? digits : `0${digits}`;
                     const groups = [];
-                    for (let i = 0; i < normalized.length; i += 2) {
-                        groups.push(normalized.slice(i, i + 2));
+                    const pairLimit = Math.floor(digits.length / 2) * 2;
+                    for (let i = 0; i < pairLimit; i += 2) {
+                        groups.push(digits.slice(i, i + 2));
                     }
-                    bulkInput.value = groups.join("+");
+                    const remainder = digits.slice(pairLimit);
+                    bulkInput.value = remainder ? `${groups.join("+")}${groups.length ? "+" : ""}${remainder}` : groups.join("+");
                 });
             }
 

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -336,7 +336,7 @@
 
             if (feedback) feedback.textContent = `${values.length} número(s) procesado(s) desde texto.`;
 
-            const modalElement = document.getElementById("pasteNumbersModal");
+            const modalElement = document.getElementById("numbersModal");
             if (modalElement && window.bootstrap?.Modal) {
                 const instance = bootstrap.Modal.getInstance(modalElement);
                 if (instance) instance.hide();

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -245,7 +245,7 @@
                 const chip = document.createElement("button");
                 chip.type = "button";
                 chip.className = "numbers-chip";
-                chip.textContent = count > 1 ? `${number} x${count} ×` : `${number} ×`;
+                chip.innerHTML = `<span>${number}</span><span class="numbers-chip-badge">${count}</span>`;
                 chip.onclick = function () {
                     const current = selectedNumberCounts.get(number) ?? 1;
                     if (current > 1) {
@@ -289,9 +289,19 @@
             buttons.forEach(btn => {
                 const value = btn.dataset.value;
                 const count = selectedNumberCounts.get(value) ?? 0;
-                btn.title = count > 0 ? `Cantidad: ${count}` : "Cantidad: 0";
                 btn.classList.toggle("btn-success", selectedNumbers.includes(value));
                 btn.classList.toggle("btn-outline-secondary", !selectedNumbers.includes(value));
+                let badge = btn.querySelector(".number-cell-badge");
+                if (count > 0) {
+                    if (!badge) {
+                        badge = document.createElement("span");
+                        badge.className = "number-cell-badge";
+                        btn.appendChild(badge);
+                    }
+                    badge.textContent = String(count);
+                } else if (badge) {
+                    badge.remove();
+                }
             });
         }
 
@@ -387,9 +397,8 @@
         }
 
         function parseNumbersFromText(raw) {
-            if (!raw) return [];
-            const sanitized = raw.replace(/[\[\]\(\)"'“”‘’]/g, " ");
-            const chunks = sanitized.split(/[^0-9]+/).filter(Boolean);
+            if (!raw) return { unique: [], expanded: [] };
+            const chunks = raw.split("+").map(x => x.trim()).filter(Boolean);
             const unique = new Set();
             const expanded = [];
 
@@ -426,11 +435,6 @@
 
             if (feedback) feedback.textContent = `${parsed.expanded.length} número(s) procesado(s) desde texto.`;
 
-            const modalElement = document.getElementById("numbersModal");
-            if (modalElement && window.bootstrap?.Modal) {
-                const instance = bootstrap.Modal.getInstance(modalElement);
-                if (instance) instance.hide();
-            }
         }
 
         function clearBulkNumbersInput() {
@@ -510,6 +514,7 @@
                 if (rule === "even" && i % 2 === 0) values.push(value);
                 if (rule === "odd" && i % 2 !== 0) values.push(value);
                 if (rule === "prime" && isPrime(i)) values.push(value);
+                if (rule === "m5" && i % 5 === 0) values.push(value);
                 if (rule === "startsWith" && value.startsWith(String(digit))) values.push(value);
                 if (rule === "endsWith" && value.endsWith(String(digit))) values.push(value);
             }
@@ -517,7 +522,7 @@
         }
 
         function syncRuleButtons() {
-            ["even", "odd", "prime"].forEach(rule => {
+            ["even", "odd", "prime", "m5"].forEach(rule => {
                 const button = document.getElementById(`rule-${rule}`);
                 if (!button) return;
                 const isActive = appliedRuleValues.has(rule);
@@ -628,12 +633,24 @@
 
         $(document).ready(function () {
             const numberInput = document.getElementById('number');
+            const bulkInput = document.getElementById('bulkNumbersInput');
             if (numberInput) {
                 buildNumberGrid();
                 bindGridDragSelection();
                 renderSelectedNumbers();
                 syncRuleButtons();
                 syncAdvancedButtons();
+            }
+            if (bulkInput) {
+                bulkInput.addEventListener("input", function () {
+                    const digits = (bulkInput.value.match(/\d/g) || []).join("");
+                    const normalized = digits.length % 2 === 0 ? digits : `0${digits}`;
+                    const groups = [];
+                    for (let i = 0; i < normalized.length; i += 2) {
+                        groups.push(normalized.slice(i, i + 2));
+                    }
+                    bulkInput.value = groups.join("+");
+                });
             }
 
             $('#addNumberForm').submit(function (e) {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -212,7 +212,6 @@
 
         let selectedNumbers = [];
         const appliedRuleValues = new Map();
-        let speechRecognitionInstance = null;
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -359,59 +358,6 @@
             const feedback = document.getElementById("numberFeedback");
             if (input) input.value = "";
             if (feedback) feedback.textContent = "";
-        }
-
-        function setVoiceInputState(isListening) {
-            const startButton = document.getElementById("voiceInputStart");
-            const stopButton = document.getElementById("voiceInputStop");
-            if (startButton) startButton.disabled = isListening;
-            if (stopButton) stopButton.disabled = !isListening;
-        }
-
-        function toggleVoiceInput(shouldStart) {
-            const feedback = document.getElementById("numberFeedback");
-            const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-
-            if (!SpeechRecognition) {
-                if (feedback) feedback.textContent = "Tu navegador no soporta dictado por voz. Puedes pegar una transcripción.";
-                return;
-            }
-
-            if (shouldStart) {
-                speechRecognitionInstance = new SpeechRecognition();
-                speechRecognitionInstance.lang = "es-ES";
-                speechRecognitionInstance.interimResults = false;
-                speechRecognitionInstance.continuous = false;
-
-                speechRecognitionInstance.onstart = function () {
-                    setVoiceInputState(true);
-                    if (feedback) feedback.textContent = "Escuchando... di los números como prefieras.";
-                };
-
-                speechRecognitionInstance.onresult = function (event) {
-                    const transcript = Array.from(event.results).map(r => r[0]?.transcript || "").join(" ").trim();
-                    const input = document.getElementById("bulkNumbersInput");
-                    if (input && transcript) {
-                        input.value = input.value ? `${input.value} ${transcript}` : transcript;
-                    }
-                    if (feedback) feedback.textContent = transcript ? "Audio transcrito. Ahora puedes Agregar o Reemplazar." : "No se detectó texto útil.";
-                };
-
-                speechRecognitionInstance.onerror = function () {
-                    if (feedback) feedback.textContent = "No se pudo transcribir el audio. Intenta de nuevo o pega texto.";
-                };
-
-                speechRecognitionInstance.onend = function () {
-                    setVoiceInputState(false);
-                };
-
-                speechRecognitionInstance.start();
-                return;
-            }
-
-            if (speechRecognitionInstance) {
-                speechRecognitionInstance.stop();
-            }
         }
 
         function selectRange() {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -211,6 +211,7 @@
         }
 
         let selectedNumbers = [];
+        const selectedNumberCounts = new Map();
         const appliedRuleValues = new Map();
         const appliedAdvancedValues = new Map();
 
@@ -226,16 +227,28 @@
             const placeholder = document.getElementById("numberPlaceholder");
             if (!hiddenInput || !container) return;
 
-            hiddenInput.value = selectedNumbers.join("+");
+            const expanded = [];
+            selectedNumbers.forEach(number => {
+                const count = selectedNumberCounts.get(number) ?? 1;
+                for (let i = 0; i < count; i++) expanded.push(number);
+            });
+            hiddenInput.value = expanded.join("+");
             container.innerHTML = "";
 
             selectedNumbers.forEach(number => {
+                const count = selectedNumberCounts.get(number) ?? 1;
                 const chip = document.createElement("button");
                 chip.type = "button";
                 chip.className = "btn btn-sm btn-primary";
-                chip.textContent = `${number} ×`;
+                chip.textContent = count > 1 ? `${number} x${count} ×` : `${number} ×`;
                 chip.onclick = function () {
-                    selectedNumbers = selectedNumbers.filter(x => x !== number);
+                    const current = selectedNumberCounts.get(number) ?? 1;
+                    if (current > 1) {
+                        selectedNumberCounts.set(number, current - 1);
+                    } else {
+                        selectedNumberCounts.delete(number);
+                        selectedNumbers = selectedNumbers.filter(x => x !== number);
+                    }
                     syncNumberPalette();
                     renderSelectedNumbers();
                 };
@@ -260,18 +273,18 @@
         }
 
         function toggleNumberSelection(value) {
-            if (selectedNumbers.includes(value)) {
-                selectedNumbers = selectedNumbers.filter(x => x !== value);
-            } else {
+            if (!selectedNumbers.includes(value)) {
                 selectedNumbers.push(value);
                 selectedNumbers.sort();
             }
+            selectedNumberCounts.set(value, (selectedNumberCounts.get(value) ?? 0) + 1);
             syncNumberPalette();
             renderSelectedNumbers();
         }
 
         function clearSelectedNumbers() {
             selectedNumbers = [];
+            selectedNumberCounts.clear();
             appliedRuleValues.clear();
             appliedAdvancedValues.clear();
             syncRuleButtons();
@@ -284,13 +297,21 @@
             const union = new Set(selectedNumbers);
             values.forEach(v => union.add(v));
             selectedNumbers = Array.from(union).sort();
+            values.forEach(v => selectedNumberCounts.set(v, (selectedNumberCounts.get(v) ?? 0) + 1));
             syncNumberPalette();
             renderSelectedNumbers();
         }
 
         function removeValues(values) {
-            const toRemove = new Set(values);
-            selectedNumbers = selectedNumbers.filter(v => !toRemove.has(v));
+            values.forEach(value => {
+                const current = selectedNumberCounts.get(value) ?? 0;
+                if (current > 1) {
+                    selectedNumberCounts.set(value, current - 1);
+                } else {
+                    selectedNumberCounts.delete(value);
+                    selectedNumbers = selectedNumbers.filter(v => v !== value);
+                }
+            });
             syncNumberPalette();
             renderSelectedNumbers();
         }
@@ -320,12 +341,16 @@
             const sanitized = raw.replace(/[\[\]\(\)"'“”‘’]/g, " ");
             const chunks = sanitized.split(/[^0-9]+/).filter(Boolean);
             const unique = new Set();
+            const expanded = [];
 
             chunks.forEach(chunk => {
-                explodeDigitChunk(chunk).forEach(value => unique.add(value));
+                explodeDigitChunk(chunk).forEach(value => {
+                    unique.add(value);
+                    expanded.push(value);
+                });
             });
 
-            return Array.from(unique).sort();
+            return { unique: Array.from(unique).sort(), expanded };
         }
 
         function applyPastedNumbers(replaceSelection) {
@@ -333,21 +358,23 @@
             const feedback = document.getElementById("numberFeedback");
             if (!input) return;
 
-            const values = parseNumbersFromText(input.value);
-            if (!values.length) {
+            const parsed = parseNumbersFromText(input.value);
+            if (!parsed.unique.length) {
                 if (feedback) feedback.textContent = "No se encontraron números válidos. Usa valores de 0 a 99.";
                 return;
             }
 
             if (replaceSelection) {
-                selectedNumbers = values;
+                selectedNumbers = parsed.unique;
+                selectedNumberCounts.clear();
+                parsed.expanded.forEach(v => selectedNumberCounts.set(v, (selectedNumberCounts.get(v) ?? 0) + 1));
                 syncNumberPalette();
                 renderSelectedNumbers();
             } else {
-                addUniqueValues(values);
+                addUniqueValues(parsed.expanded);
             }
 
-            if (feedback) feedback.textContent = `${values.length} número(s) procesado(s) desde texto.`;
+            if (feedback) feedback.textContent = `${parsed.expanded.length} número(s) procesado(s) desde texto.`;
 
             const modalElement = document.getElementById("numbersModal");
             if (modalElement && window.bootstrap?.Modal) {
@@ -508,6 +535,8 @@
                 [pool[i], pool[j]] = [pool[j], pool[i]];
             }
             selectedNumbers = pool.slice(0, count).sort();
+            selectedNumberCounts.clear();
+            selectedNumbers.forEach(v => selectedNumberCounts.set(v, 1));
             appliedRuleValues.clear();
             appliedAdvancedValues.clear();
             syncRuleButtons();
@@ -521,6 +550,7 @@
             const countInput = document.getElementById("randomCount");
             const feedback = document.getElementById("numberFeedback");
             if (countInput) countInput.value = "";
+            clearSelectedNumbers();
             if (feedback) feedback.textContent = "";
         }
 

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -282,6 +282,43 @@
             renderSelectedNumbers();
         }
 
+        function parseNumbersFromText(raw) {
+            if (!raw) return [];
+            const sanitized = raw.replace(/[\[\]\(\)"'“”‘’]/g, " ");
+            const chunks = sanitized.split(/[^0-9]+/).filter(Boolean);
+            const unique = new Set();
+
+            chunks.forEach(chunk => {
+                const number = parseInt(chunk, 10);
+                if (Number.isNaN(number) || number < 0 || number > 99) return;
+                unique.add(padNumber(number));
+            });
+
+            return Array.from(unique).sort();
+        }
+
+        function applyPastedNumbers(replaceSelection) {
+            const input = document.getElementById("bulkNumbersInput");
+            const feedback = document.getElementById("numberFeedback");
+            if (!input) return;
+
+            const values = parseNumbersFromText(input.value);
+            if (!values.length) {
+                if (feedback) feedback.textContent = "No se encontraron números válidos. Usa valores de 0 a 99.";
+                return;
+            }
+
+            if (replaceSelection) {
+                selectedNumbers = values;
+                syncNumberPalette();
+                renderSelectedNumbers();
+            } else {
+                addUniqueValues(values);
+            }
+
+            if (feedback) feedback.textContent = `${values.length} número(s) procesado(s) desde texto.`;
+        }
+
         function selectRange() {
             const startInput = document.getElementById("rangeStart");
             const endInput = document.getElementById("rangeEnd");
@@ -363,7 +400,6 @@
                 button.dataset.value = value;
                 button.className = "btn btn-sm btn-outline-secondary number-cell";
                 button.textContent = value;
-                button.style.minWidth = "48px";
                 button.onclick = function () { toggleNumberSelection(value); };
                 grid.appendChild(button);
             }

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -343,6 +343,13 @@
             }
         }
 
+        function clearBulkNumbersInput() {
+            const input = document.getElementById("bulkNumbersInput");
+            const feedback = document.getElementById("numberFeedback");
+            if (input) input.value = "";
+            if (feedback) feedback.textContent = "";
+        }
+
         function selectRange() {
             const startInput = document.getElementById("rangeStart");
             const endInput = document.getElementById("rangeEnd");

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -9,10 +9,12 @@
 
 <style>
     .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
-    .number-grid .number-cell { width:100%; min-width:0 !important; padding: .2rem .1rem; font-size: .72rem; line-height: 1.1; }
+    .number-grid .number-cell { position: relative; width:100%; min-width:0 !important; padding: .35rem .1rem; font-size: .72rem; line-height: 1.1; border-radius: 12px; }
     .numbers-summary { min-height: 44px; }
     .numbers-modal-trigger { white-space: nowrap; }
-    .numbers-chip { border: 0; background: #0d6efd; color: #fff; border-radius: 999px; padding: .2rem .55rem; font-size: .78rem; }
+    .numbers-chip { border: 0; background: #f2f4f8; color: #1f2937; border-radius: 999px; padding: .25rem .35rem .25rem .65rem; font-size: .78rem; display:inline-flex; align-items:center; gap:.35rem; }
+    .numbers-chip-badge { background:#0d6efd; color:#fff; border-radius:999px; font-size:.72rem; font-weight:700; min-width:26px; text-align:center; padding:.1rem .45rem; }
+    .number-cell-badge { position:absolute; top:2px; right:2px; background:#0d6efd; color:#fff; border-radius:999px; font-size:.62rem; line-height:1; padding:.15rem .3rem; min-width:20px; text-align:center; }
 </style>
 
 <form asp-action="Add" id="addNumberForm">
@@ -105,6 +107,7 @@
                                     <button type="button" id="rule-even" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('even')">Pares</button>
                                     <button type="button" id="rule-odd" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('odd')">Impares</button>
                                     <button type="button" id="rule-prime" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('prime')">Primos</button>
+                                    <button type="button" id="rule-m5" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('m5')">Múltiplos 5</button>
                                 </div>
                             </div>
                             <div class="col-12 col-md-6">
@@ -142,8 +145,8 @@
                         <div id="collapsePaste" class="accordion-collapse collapse show" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
                             <div class="accordion-body">
                             <label class="form-label mb-1">Pegar lista de números</label>
-                            <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
-                            <small class="text-muted d-block mt-2">Funciona con texto libre: "metele 00, 1 y 78".</small>
+                            <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: 00+01+78'></textarea>
+                            <small class="text-muted d-block mt-2">Solo dígitos. Se formatea automáticamente como 00+01+78.</small>
                             <div class="d-flex flex-wrap gap-1 mt-2">
                                 <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
                                 <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -87,9 +87,9 @@
                         <div class="col-12">
                             <label class="form-label mb-1">Reglas rápidas</label>
                             <div class="d-flex flex-wrap gap-1">
-                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
-                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
-                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
+                                <button type="button" id="rule-even" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('even')">Pares</button>
+                                <button type="button" id="rule-odd" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('odd')">Impares</button>
+                                <button type="button" id="rule-prime" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('prime')">Primos</button>
                             </div>
                         </div>
                         <div class="col-12 col-md-6">
@@ -104,6 +104,13 @@
                             <div class="input-group input-group-sm">
                                 <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
                                 <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label mb-1">A Gallo Tapado</label>
+                            <div class="input-group input-group-sm">
+                                <input type="number" id="randomCount" class="form-control" min="1" max="100" placeholder="Cantidad (1-100)" />
+                                <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
                             </div>
                         </div>
                     </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -9,7 +9,7 @@
 
 <style>
     .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
-    .number-grid .number-cell { width:100%; min-width:0 !important; }
+    .number-grid .number-cell { width:100%; min-width:0 !important; padding: .2rem .1rem; font-size: .72rem; line-height: 1.1; }
     .numbers-summary { min-height: 44px; }
 </style>
 
@@ -67,7 +67,7 @@
         <div class="row g-3">
             <div class="col-lg-7">
                 <div class="border rounded bg-white p-2 shadow-sm">
-                    <div id="numberPalette" style="max-height: 320px; overflow-y: auto;">
+                    <div id="numberPalette">
                         <div id="numberGrid" class="number-grid"></div>
                     </div>
                 </div>
@@ -118,11 +118,7 @@
                 <div class="border rounded bg-white p-2 shadow-sm">
                     <label class="form-label mb-1">Pegar lista de números</label>
                     <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
-                    <small class="text-muted d-block mt-2">También funciona con texto libre (ej. transcripción de audio): "metele 00, 1 y 78".</small>
-                    <div class="d-flex flex-wrap gap-1 mt-2">
-                        <button type="button" id="voiceInputStart" class="btn btn-sm btn-outline-info" onclick="toggleVoiceInput(true)">🎤 Dictar</button>
-                        <button type="button" id="voiceInputStop" class="btn btn-sm btn-outline-secondary" onclick="toggleVoiceInput(false)" disabled>Detener</button>
-                    </div>
+                    <small class="text-muted d-block mt-2">Funciona con texto libre: "metele 00, 1 y 78".</small>
                     <div class="d-flex flex-wrap gap-1 mt-2">
                         <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
                         <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -57,7 +57,7 @@
 <hr />
 
 <div class="modal fade" id="numbersModal" tabindex="-1" aria-labelledby="numbersModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+  <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="numbersModalLabel">Gestión de números</h5>
@@ -81,7 +81,7 @@
                                 <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
                                 <span class="input-group-text">a</span>
                                 <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
-                                <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
+                                <button type="button" id="rangeApplyButton" class="btn btn-outline-primary" onclick="applyOrToggleRange()">Aplicar</button>
                             </div>
                         </div>
                         <div class="col-12">
@@ -96,14 +96,14 @@
                             <label class="form-label mb-1">Inician en</label>
                             <div class="input-group input-group-sm">
                                 <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                                <button type="button" class="btn btn-outline-secondary" onclick="applyStartsWithDigit()">Aplicar</button>
+                                <button type="button" id="startsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleStartsWithDigit()">Aplicar</button>
                             </div>
                         </div>
                         <div class="col-12 col-md-6">
                             <label class="form-label mb-1">Terminan en</label>
                             <div class="input-group input-group-sm">
                                 <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                                <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
+                                <button type="button" id="endsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleEndsWithDigit()">Aplicar</button>
                             </div>
                         </div>
                         <div class="col-12">
@@ -111,6 +111,7 @@
                             <div class="input-group input-group-sm">
                                 <input type="number" id="randomCount" class="form-control" min="1" max="100" placeholder="Cantidad (1-100)" />
                                 <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
                             </div>
                         </div>
                     </div>
@@ -127,9 +128,6 @@
                 </div>
             </div>
         </div>
-      </div>
-      <div class="modal-footer">
-        <small class="text-muted">Agregar = suma a selección actual / Reemplazar = borra selección actual y usa solo lo pegado.</small>
       </div>
     </div>
   </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -38,7 +38,7 @@
             </div>
             <div class="d-flex align-items-center gap-2 mb-2">
                 <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#numbersModal">
-                    Gestionar números
+                    Números
                 </button>
                 <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">Limpiar</button>
                 <small class="text-muted">Abre el modal para seleccionar, reglas rápidas o pegar lista.</small>
@@ -112,17 +112,17 @@
                     <label class="form-label mb-1">Pegar lista de números</label>
                     <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
                     <small class="text-muted d-block mt-2">Separadores libres y concatenados, siempre se normaliza a 2 dígitos (00-99).</small>
+                    <div class="d-flex flex-wrap gap-1 mt-2">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
+                        <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
+                        <button type="button" class="btn btn-sm btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
+                    </div>
                 </div>
             </div>
         </div>
       </div>
-      <div class="modal-footer d-flex justify-content-between">
-        <small class="text-muted">Agregar = suma a selección actual / Reemplazar = borra lo actual y usa solo lo pegado.</small>
-        <div class="d-flex gap-2">
-          <button type="button" class="btn btn-outline-danger" onclick="clearSelectedNumbers()">Limpiar</button>
-          <button type="button" class="btn btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
-          <button type="button" class="btn btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
-        </div>
+      <div class="modal-footer">
+        <small class="text-muted">Agregar = suma a selección actual / Reemplazar = borra selección actual y usa solo lo pegado.</small>
       </div>
     </div>
   </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -34,6 +34,10 @@
         <div class="form-group col-md-7">
             <label asp-for="Value" class="control-label">Números</label>
             <input asp-for="Value" id="number" type="hidden" />
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm numbers-summary">
+                <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainerOutside"></div>
+                <small id="numberPlaceholderOutside" class="text-muted">Aún no has seleccionado números</small>
+            </div>
             <div class="d-flex align-items-center gap-2 mb-2">
                 <button type="button" class="btn btn-sm btn-outline-primary numbers-modal-trigger" data-bs-toggle="modal" data-bs-target="#numbersModal" title="Abrir selector de números">
                     <span class="material-icons" style="font-size:16px;vertical-align:text-bottom;">grid_view</span>
@@ -62,27 +66,30 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body p-2 p-lg-3">
-        <div class="border rounded bg-white p-2 shadow-sm mb-2">
-            <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
-            <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
-        </div>
-        <div class="border rounded bg-white p-2 shadow-sm mb-3">
-            <div id="numberPalette">
-                <div id="numberGrid" class="number-grid"></div>
+        <div class="row g-3">
+            <div class="col-lg-7">
+                <div class="border rounded bg-white p-2 shadow-sm mb-2">
+                    <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
+                    <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+                </div>
+                <div class="border rounded bg-white p-2 shadow-sm mb-3">
+                    <div id="numberPalette">
+                        <div id="numberGrid" class="number-grid"></div>
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección</button>
+                </div>
             </div>
-            <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección</button>
-        </div>
-
-        <div class="accordion" id="numbersAccordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="headingRules">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRules" aria-expanded="false" aria-controls="collapseRules">
-                        Reglas y filtros rápidos
-                    </button>
-                </h2>
-                <div id="collapseRules" class="accordion-collapse collapse" aria-labelledby="headingRules" data-bs-parent="#numbersAccordion">
-                    <div class="accordion-body">
-                        <div class="row g-2 align-items-end">
+            <div class="col-lg-5">
+                <div class="accordion" id="numbersAccordion">
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingRules">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRules" aria-expanded="false" aria-controls="collapseRules">
+                                Reglas y filtros rápidos
+                            </button>
+                        </h2>
+                        <div id="collapseRules" class="accordion-collapse collapse" aria-labelledby="headingRules" data-bs-parent="#numbersAccordion">
+                            <div class="accordion-body">
+                                <div class="row g-2 align-items-end">
                             <div class="col-12">
                                 <label class="form-label mb-1">Rango consecutivo</label>
                                 <div class="input-group input-group-sm">
@@ -122,31 +129,32 @@
                                     <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
                                 </div>
                             </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingPaste">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="true" aria-controls="collapsePaste">
+                                Copiar / pegar números
+                            </button>
+                        </h2>
+                        <div id="collapsePaste" class="accordion-collapse collapse show" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
+                            <div class="accordion-body">
+                            <label class="form-label mb-1">Pegar lista de números</label>
+                            <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
+                            <small class="text-muted d-block mt-2">Funciona con texto libre: "metele 00, 1 y 78".</small>
+                            <div class="d-flex flex-wrap gap-1 mt-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
+                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
+                                <button type="button" class="btn btn-sm btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
+                            </div>
+                        </div>
                         </div>
                     </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="headingPaste">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="true" aria-controls="collapsePaste">
-                        Copiar / pegar números
-                    </button>
-                </h2>
-                <div id="collapsePaste" class="accordion-collapse collapse show" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
-                    <div class="accordion-body">
-                    <label class="form-label mb-1">Pegar lista de números</label>
-                    <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
-                    <small class="text-muted d-block mt-2">Funciona con texto libre: "metele 00, 1 y 78".</small>
-                    <div class="d-flex flex-wrap gap-1 mt-2">
-                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
-                        <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
-                        <button type="button" class="btn btn-sm btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
-                    </div>
-                </div>
-                </div>
-            </div>
         </div>
       </div>
-    </div>
   </div>
 </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -12,6 +12,7 @@
     .number-grid .number-cell { width:100%; min-width:0 !important; padding: .2rem .1rem; font-size: .72rem; line-height: 1.1; }
     .numbers-summary { min-height: 44px; }
     .numbers-modal-trigger { white-space: nowrap; }
+    .numbers-chip { border: 0; background: #0d6efd; color: #fff; border-radius: 999px; padding: .2rem .55rem; font-size: .78rem; }
 </style>
 
 <form asp-action="Add" id="addNumberForm">
@@ -30,19 +31,15 @@
                 <span asp-validation-for="Busted" class="text-danger"></span>
             </div>
         }
-        <div class="form-group col-md-6">
+        <div class="form-group col-md-7">
             <label asp-for="Value" class="control-label">Números</label>
             <input asp-for="Value" id="number" type="hidden" />
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm numbers-summary" id="selectedNumbersInputLike">
-                <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
-                <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
-            </div>
             <div class="d-flex align-items-center gap-2 mb-2">
                 <button type="button" class="btn btn-sm btn-outline-primary numbers-modal-trigger" data-bs-toggle="modal" data-bs-target="#numbersModal" title="Abrir selector de números">
                     <span class="material-icons" style="font-size:16px;vertical-align:text-bottom;">grid_view</span>
-                    Selector
+                    Gestionar números
                 </button>
-                <small class="text-muted">Abre el modal para seleccionar, reglas rápidas o pegar lista.</small>
+                <small class="text-muted">Todo el CRUD de números se realiza dentro del modal.</small>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
@@ -58,23 +55,41 @@
 <hr />
 
 <div class="modal fade" id="numbersModal" tabindex="-1" aria-labelledby="numbersModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-fullscreen-lg-down modal-xl">
+  <div class="modal-dialog modal-fullscreen-lg-down modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="numbersModalLabel">Gestión de números</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body">
-        <div class="row g-3">
-            <div class="col-lg-7">
-                <div class="border rounded bg-white p-2 shadow-sm">
-                    <div id="numberPalette">
-                        <div id="numberGrid" class="number-grid"></div>
+      <div class="modal-body p-2 p-lg-3">
+        <div class="accordion" id="numbersAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingGrid">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGrid" aria-expanded="true" aria-controls="collapseGrid">
+                        Selector 00-99
+                    </button>
+                </h2>
+                <div id="collapseGrid" class="accordion-collapse collapse show" aria-labelledby="headingGrid" data-bs-parent="#numbersAccordion">
+                    <div class="accordion-body">
+                        <div class="border rounded bg-white p-2 shadow-sm mb-2">
+                            <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
+                            <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+                        </div>
+                        <div id="numberPalette">
+                            <div id="numberGrid" class="number-grid"></div>
+                        </div>
+                        <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección del grid</button>
                     </div>
                 </div>
             </div>
-            <div class="col-lg-5">
-                <div class="border rounded bg-white p-2 mb-2 shadow-sm">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingRules">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRules" aria-expanded="false" aria-controls="collapseRules">
+                        Reglas y filtros rápidos
+                    </button>
+                </h2>
+                <div id="collapseRules" class="accordion-collapse collapse" aria-labelledby="headingRules" data-bs-parent="#numbersAccordion">
+                    <div class="accordion-body">
                     <div class="row g-2 align-items-end">
                         <div class="col-12">
                             <label class="form-label mb-1">Rango consecutivo</label>
@@ -115,12 +130,18 @@
                                 <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
                             </div>
                         </div>
-                        <div class="col-12">
-                            <button type="button" class="btn btn-sm btn-outline-danger w-100" onclick="clearSelectedNumbers()">Limpiar selección del grid</button>
-                        </div>
                     </div>
                 </div>
-                <div class="border rounded bg-white p-2 shadow-sm">
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingPaste">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="false" aria-controls="collapsePaste">
+                        Copiar / pegar números
+                    </button>
+                </h2>
+                <div id="collapsePaste" class="accordion-collapse collapse" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
+                    <div class="accordion-body">
                     <label class="form-label mb-1">Pegar lista de números</label>
                     <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
                     <small class="text-muted d-block mt-2">Funciona con texto libre: "metele 00, 1 y 78".</small>
@@ -129,6 +150,7 @@
                         <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
                         <button type="button" class="btn btn-sm btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
                     </div>
+                </div>
                 </div>
             </div>
         </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -118,7 +118,11 @@
                 <div class="border rounded bg-white p-2 shadow-sm">
                     <label class="form-label mb-1">Pegar lista de números</label>
                     <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
-                    <small class="text-muted d-block mt-2">Separadores libres y concatenados, siempre se normaliza a 2 dígitos (00-99).</small>
+                    <small class="text-muted d-block mt-2">También funciona con texto libre (ej. transcripción de audio): "metele 00, 1 y 78".</small>
+                    <div class="d-flex flex-wrap gap-1 mt-2">
+                        <button type="button" id="voiceInputStart" class="btn btn-sm btn-outline-info" onclick="toggleVoiceInput(true)">🎤 Dictar</button>
+                        <button type="button" id="voiceInputStop" class="btn btn-sm btn-outline-secondary" onclick="toggleVoiceInput(false)" disabled>Detener</button>
+                    </div>
                     <div class="d-flex flex-wrap gap-1 mt-2">
                         <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
                         <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -7,6 +7,11 @@
 
 <hr />
 
+<style>
+    .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
+    .number-grid .number-cell { width:100%; min-width:0 !important; }
+</style>
+
 <form asp-action="Add" id="addNumberForm">
     <div class="row g-3">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -76,8 +81,18 @@
                     </div>
                 </div>
             </div>
+
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm">
+                <label class="form-label mb-1">Pegar lista de números</label>
+                <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="2" placeholder='Ej: "00 01 78", "00+01+78", "0, 1, 78"'></textarea>
+                <div class="d-flex flex-wrap gap-1 mt-2">
+                    <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar desde texto</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyPastedNumbers(true)">Reemplazar con texto</button>
+                </div>
+                <small class="text-muted">Soporta espacios, comas, +, guiones y saltos de línea. Siempre se normaliza a 2 dígitos (00-99).</small>
+            </div>
             <div id="numberPalette" class="border rounded bg-white p-2 shadow-sm" style="max-height: 240px; overflow-y: auto;">
-                <div id="numberGrid" class="d-flex flex-wrap gap-1"></div>
+                <div id="numberGrid" class="number-grid"></div>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -39,7 +39,7 @@
                     <span class="material-icons" style="font-size:16px;vertical-align:text-bottom;">grid_view</span>
                     Gestionar números
                 </button>
-                <small class="text-muted">Todo el CRUD de números se realiza dentro del modal.</small>
+                <small class="text-muted">Aquí puedes elegir números, aplicar filtros o pegar listas.</small>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
@@ -62,26 +62,18 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body p-2 p-lg-3">
-        <div class="accordion" id="numbersAccordion">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="headingGrid">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGrid" aria-expanded="true" aria-controls="collapseGrid">
-                        Selector 00-99
-                    </button>
-                </h2>
-                <div id="collapseGrid" class="accordion-collapse collapse show" aria-labelledby="headingGrid" data-bs-parent="#numbersAccordion">
-                    <div class="accordion-body">
-                        <div class="border rounded bg-white p-2 shadow-sm mb-2">
-                            <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
-                            <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
-                        </div>
-                        <div id="numberPalette">
-                            <div id="numberGrid" class="number-grid"></div>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección del grid</button>
-                    </div>
-                </div>
+        <div class="border rounded bg-white p-2 shadow-sm mb-2">
+            <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
+            <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+        </div>
+        <div class="border rounded bg-white p-2 shadow-sm mb-3">
+            <div id="numberPalette">
+                <div id="numberGrid" class="number-grid"></div>
             </div>
+            <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección</button>
+        </div>
+
+        <div class="accordion" id="numbersAccordion">
             <div class="accordion-item">
                 <h2 class="accordion-header" id="headingRules">
                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRules" aria-expanded="false" aria-controls="collapseRules">
@@ -90,57 +82,57 @@
                 </h2>
                 <div id="collapseRules" class="accordion-collapse collapse" aria-labelledby="headingRules" data-bs-parent="#numbersAccordion">
                     <div class="accordion-body">
-                    <div class="row g-2 align-items-end">
-                        <div class="col-12">
-                            <label class="form-label mb-1">Rango consecutivo</label>
-                            <div class="input-group input-group-sm">
-                                <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
-                                <span class="input-group-text">a</span>
-                                <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
-                                <button type="button" id="rangeApplyButton" class="btn btn-outline-primary" onclick="applyOrToggleRange()">Aplicar</button>
+                        <div class="row g-2 align-items-end">
+                            <div class="col-12">
+                                <label class="form-label mb-1">Rango consecutivo</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
+                                    <span class="input-group-text">a</span>
+                                    <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
+                                    <button type="button" id="rangeApplyButton" class="btn btn-outline-primary" onclick="applyOrToggleRange()">Aplicar</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-12">
-                            <label class="form-label mb-1">Reglas rápidas</label>
-                            <div class="d-flex flex-wrap gap-1">
-                                <button type="button" id="rule-even" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('even')">Pares</button>
-                                <button type="button" id="rule-odd" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('odd')">Impares</button>
-                                <button type="button" id="rule-prime" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('prime')">Primos</button>
+                            <div class="col-12">
+                                <label class="form-label mb-1">Reglas rápidas</label>
+                                <div class="d-flex flex-wrap gap-1">
+                                    <button type="button" id="rule-even" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('even')">Pares</button>
+                                    <button type="button" id="rule-odd" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('odd')">Impares</button>
+                                    <button type="button" id="rule-prime" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('prime')">Primos</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-md-6">
-                            <label class="form-label mb-1">Inician en</label>
-                            <div class="input-group input-group-sm">
-                                <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                                <button type="button" id="startsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleStartsWithDigit()">Aplicar</button>
+                            <div class="col-12 col-md-6">
+                                <label class="form-label mb-1">Inician en</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                    <button type="button" id="startsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleStartsWithDigit()">Aplicar</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-12 col-md-6">
-                            <label class="form-label mb-1">Terminan en</label>
-                            <div class="input-group input-group-sm">
-                                <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                                <button type="button" id="endsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleEndsWithDigit()">Aplicar</button>
+                            <div class="col-12 col-md-6">
+                                <label class="form-label mb-1">Terminan en</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                    <button type="button" id="endsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleEndsWithDigit()">Aplicar</button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-12">
-                            <label class="form-label mb-1">A Gallo Tapado</label>
-                            <div class="input-group input-group-sm">
-                                <input type="number" id="randomCount" class="form-control" min="1" max="100" placeholder="Cantidad (1-100)" />
-                                <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
-                                <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
+                            <div class="col-12">
+                                <label class="form-label mb-1">A Gallo Tapado</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="randomCount" class="form-control" min="1" max="100" placeholder="Cantidad (1-100)" />
+                                    <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
+                                    <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                </div>
             </div>
             <div class="accordion-item">
                 <h2 class="accordion-header" id="headingPaste">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="false" aria-controls="collapsePaste">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="true" aria-controls="collapsePaste">
                         Copiar / pegar números
                     </button>
                 </h2>
-                <div id="collapsePaste" class="accordion-collapse collapse" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
+                <div id="collapsePaste" class="accordion-collapse collapse show" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
                     <div class="accordion-body">
                     <label class="form-label mb-1">Pegar lista de números</label>
                     <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -10,6 +10,7 @@
 <style>
     .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
     .number-grid .number-cell { width:100%; min-width:0 !important; }
+    .numbers-summary { min-height: 44px; }
 </style>
 
 <form asp-action="Add" id="addNumberForm">
@@ -31,65 +32,16 @@
         <div class="form-group col-md-6">
             <label asp-for="Value" class="control-label">Números</label>
             <input asp-for="Value" id="number" type="hidden" />
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm" id="selectedNumbersInputLike">
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm numbers-summary" id="selectedNumbersInputLike">
                 <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
                 <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
             </div>
-            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones o usa una regla rápida.</small>
             <div class="d-flex align-items-center gap-2 mb-2">
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleNumberPalette()">
-                    Mostrar/Ocultar selector
+                <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#numbersModal">
+                    Gestionar números
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">
-                    Limpiar selección
-                </button>
-            </div>
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm">
-                <div class="row g-2 align-items-end">
-                    <div class="col-md-5">
-                        <label class="form-label mb-1">Rango consecutivo</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
-                            <span class="input-group-text">a</span>
-                            <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
-                            <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
-                        </div>
-                    </div>
-                    <div class="col-md-7">
-                        <label class="form-label mb-1">Reglas rápidas</label>
-                        <div class="d-flex flex-wrap gap-1">
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
-                        </div>
-                    </div>
-                </div>
-                <div class="row g-2 mt-1">
-                    <div class="col-md-6">
-                        <label class="form-label mb-1">Inician en</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                            <button type="button" class="btn btn-outline-secondary" onclick="applyStartsWithDigit()">Aplicar</button>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <label class="form-label mb-1">Terminan en</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                            <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="d-flex align-items-center gap-2 mb-2">
-                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#pasteNumbersModal">
-                    Pegar números
-                </button>
-                <small class="text-muted">Usa este atajo si el cliente ya trae lista.</small>
-            </div>
-            <div id="numberPalette" class="border rounded bg-white p-2 shadow-sm" style="max-height: 240px; overflow-y: auto;">
-                <div id="numberGrid" class="number-grid"></div>
+                <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">Limpiar</button>
+                <small class="text-muted">Abre el modal para seleccionar, reglas rápidas o pegar lista.</small>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
@@ -104,20 +56,70 @@
 
 <hr />
 
-<div class="modal fade" id="pasteNumbersModal" tabindex="-1" aria-labelledby="pasteNumbersModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+<div class="modal fade" id="numbersModal" tabindex="-1" aria-labelledby="numbersModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="pasteNumbersModalLabel">Pegar lista de números</h5>
+        <h5 class="modal-title" id="numbersModalLabel">Gestión de números</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <textarea id="bulkNumbersInput" class="form-control" rows="4" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
-        <small class="text-muted d-block mt-2">Soporta espacios, comas, +, guiones y concatenados de dígitos. Siempre se normaliza a 2 dígitos (00-99).</small>
+        <div class="row g-3">
+            <div class="col-lg-7">
+                <div class="border rounded bg-white p-2 shadow-sm">
+                    <div id="numberPalette" style="max-height: 320px; overflow-y: auto;">
+                        <div id="numberGrid" class="number-grid"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-5">
+                <div class="border rounded bg-white p-2 mb-2 shadow-sm">
+                    <div class="row g-2 align-items-end">
+                        <div class="col-12">
+                            <label class="form-label mb-1">Rango consecutivo</label>
+                            <div class="input-group input-group-sm">
+                                <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
+                                <span class="input-group-text">a</span>
+                                <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
+                                <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label mb-1">Reglas rápidas</label>
+                            <div class="d-flex flex-wrap gap-1">
+                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
+                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
+                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
+                            </div>
+                        </div>
+                        <div class="col-12 col-md-6">
+                            <label class="form-label mb-1">Inician en</label>
+                            <div class="input-group input-group-sm">
+                                <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                <button type="button" class="btn btn-outline-secondary" onclick="applyStartsWithDigit()">Aplicar</button>
+                            </div>
+                        </div>
+                        <div class="col-12 col-md-6">
+                            <label class="form-label mb-1">Terminan en</label>
+                            <div class="input-group input-group-sm">
+                                <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="border rounded bg-white p-2 shadow-sm">
+                    <label class="form-label mb-1">Pegar lista de números</label>
+                    <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
+                    <small class="text-muted d-block mt-2">Separadores libres y concatenados, siempre se normaliza a 2 dígitos (00-99).</small>
+                </div>
+            </div>
+        </div>
       </div>
       <div class="modal-footer d-flex justify-content-between">
         <small class="text-muted">Agregar = suma a selección actual / Reemplazar = borra lo actual y usa solo lo pegado.</small>
         <div class="d-flex gap-2">
+          <button type="button" class="btn btn-outline-danger" onclick="clearSelectedNumbers()">Limpiar</button>
           <button type="button" class="btn btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
           <button type="button" class="btn btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
         </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -82,14 +82,11 @@
                 </div>
             </div>
 
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm">
-                <label class="form-label mb-1">Pegar lista de números</label>
-                <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="2" placeholder='Ej: "00 01 78", "00+01+78", "0, 1, 78"'></textarea>
-                <div class="d-flex flex-wrap gap-1 mt-2">
-                    <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar desde texto</button>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="applyPastedNumbers(true)">Reemplazar con texto</button>
-                </div>
-                <small class="text-muted">Soporta espacios, comas, +, guiones y saltos de línea. Siempre se normaliza a 2 dígitos (00-99).</small>
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#pasteNumbersModal">
+                    Pegar números
+                </button>
+                <small class="text-muted">Usa este atajo si el cliente ya trae lista.</small>
             </div>
             <div id="numberPalette" class="border rounded bg-white p-2 shadow-sm" style="max-height: 240px; overflow-y: auto;">
                 <div id="numberGrid" class="number-grid"></div>
@@ -106,3 +103,25 @@
 </form>
 
 <hr />
+
+<div class="modal fade" id="pasteNumbersModal" tabindex="-1" aria-labelledby="pasteNumbersModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="pasteNumbersModalLabel">Pegar lista de números</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <textarea id="bulkNumbersInput" class="form-control" rows="4" placeholder='Ej: "00 01 78", "00+01+78", "000178", "00,01+78 9095"'></textarea>
+        <small class="text-muted d-block mt-2">Soporta espacios, comas, +, guiones y concatenados de dígitos. Siempre se normaliza a 2 dígitos (00-99).</small>
+      </div>
+      <div class="modal-footer d-flex justify-content-between">
+        <small class="text-muted">Agregar = suma a selección actual / Reemplazar = borra lo actual y usa solo lo pegado.</small>
+        <div class="d-flex gap-2">
+          <button type="button" class="btn btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
+          <button type="button" class="btn btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -11,6 +11,7 @@
     .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
     .number-grid .number-cell { width:100%; min-width:0 !important; padding: .2rem .1rem; font-size: .72rem; line-height: 1.1; }
     .numbers-summary { min-height: 44px; }
+    .numbers-modal-trigger { white-space: nowrap; }
 </style>
 
 <form asp-action="Add" id="addNumberForm">
@@ -37,10 +38,10 @@
                 <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
             </div>
             <div class="d-flex align-items-center gap-2 mb-2">
-                <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#numbersModal">
-                    Números
+                <button type="button" class="btn btn-sm btn-outline-primary numbers-modal-trigger" data-bs-toggle="modal" data-bs-target="#numbersModal" title="Abrir selector de números">
+                    <span class="material-icons" style="font-size:16px;vertical-align:text-bottom;">grid_view</span>
+                    Selector
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">Limpiar</button>
                 <small class="text-muted">Abre el modal para seleccionar, reglas rápidas o pegar lista.</small>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
@@ -57,7 +58,7 @@
 <hr />
 
 <div class="modal fade" id="numbersModal" tabindex="-1" aria-labelledby="numbersModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
+  <div class="modal-dialog modal-fullscreen-lg-down modal-xl">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="numbersModalLabel">Gestión de números</h5>
@@ -113,6 +114,9 @@
                                 <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
                                 <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
                             </div>
+                        </div>
+                        <div class="col-12">
+                            <button type="button" class="btn btn-sm btn-outline-danger w-100" onclick="clearSelectedNumbers()">Limpiar selección del grid</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Facilitar la captura cuando los clientes pegan listas de números en distintos formatos y mantener una visual ordenada en la grilla de selección.

### Description
- Se agregó un bloque de UI en `Views/Lottery/_Add.cshtml` con un `textarea` para pegar listas y dos botones: `Agregar desde texto` y `Reemplazar con texto`.
- Se incorporaron las funciones JS `parseNumbersFromText(raw)` y `applyPastedNumbers(replaceSelection)` en `Views/Lottery/Create.cshtml` para parsear múltiples formatos (espacios, comas, `+`, guiones, comillas, paréntesis y saltos de línea) y normalizar siempre a dos dígitos (`00`–`99`).
- Se ajustó la grilla visual de números cambiando `#numberGrid` a una clase `number-grid` con `grid-template-columns: repeat(10, minmax(0, 1fr))` y se eliminó la restricción de `minWidth` en los botones para que la UI muestre como máximo 10 columnas.
- Se añadieron mensajes de feedback en `#numberFeedback` para informar cuando no hay números válidos o cuántos se procesaron, y la lógica mantiene la opción de sumar o reemplazar la selección actual.

### Testing
- Se intentó ejecutar `dotnet build -nologo` pero falló por ausencia de `dotnet` en el entorno (`/bin/bash: dotnet: command not found`).
- Se verificó el estado del repositorio con `git status --short` y se confirmó que los cambios están listos para commit.
- El commit con los cambios fue creado exitosamente (`Mejora captura de números por pegado y límite visual de 10 columnas`).
- Se creó la PR con título y descripción mediante la herramienta interna (`make_pr`) y la petición fue registrada correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c79612e083308d7253c703f933bb)