### PR TITLE
Enhance lottery number selector: modal UI, multi-select counts, drag selection, rules, paste & random pick

### DIFF
--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -643,16 +643,32 @@
             }
             if (bulkInput) {
                 bulkInput.addEventListener("input", function () {
-                    const digits = (bulkInput.value.match(/\d/g) || []).join("");
+                    const raw = bulkInput.value.replace(/[^0-9+]/g, "");
+                    const tokens = raw.split("+");
                     const groups = [];
-                    const pairLimit = Math.floor(digits.length / 2) * 2;
-                    for (let i = 0; i < pairLimit; i += 2) {
-                        groups.push(digits.slice(i, i + 2));
-                    }
-                    const remainder = digits.slice(pairLimit);
-                    if (remainder.length === 1) {
-                        groups.push(`0${remainder}`);
-                    }
+
+                    tokens.forEach((token, tokenIndex) => {
+                        if (!token) return;
+                        if (token.length <= 2) {
+                            const isSingleDigit = token.length === 1;
+                            const hasMultipleTokens = tokens.length > 1;
+                            const isLastToken = tokenIndex === tokens.length - 1;
+                            if (isSingleDigit && hasMultipleTokens && isLastToken) {
+                                groups.push(`0${token}`);
+                            } else {
+                                groups.push(token.length === 1 ? token : token);
+                            }
+                            return;
+                        }
+
+                        const pairLimit = Math.floor(token.length / 2) * 2;
+                        for (let i = 0; i < pairLimit; i += 2) {
+                            groups.push(token.slice(i, i + 2));
+                        }
+                        const remainder = token.slice(pairLimit);
+                        if (remainder) groups.push(`0${remainder}`);
+                    });
+
                     bulkInput.value = groups.join("+");
                 });
             }

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -211,6 +211,11 @@
         }
 
         let selectedNumbers = [];
+        const selectedNumberCounts = new Map();
+        const appliedRuleValues = new Map();
+        const appliedAdvancedValues = new Map();
+        let isDraggingNumbers = false;
+        let dragTouchedValues = new Set();
 
         function padNumber(value) {
             return value.toString().padStart(2, "0");
@@ -219,57 +224,131 @@
         function renderSelectedNumbers() {
             const hiddenInput = document.getElementById("number");
             const container = document.getElementById("selectedNumbersContainer");
+            const outsideContainer = document.getElementById("selectedNumbersContainerOutside");
             const feedback = document.getElementById("numberFeedback");
             const submitButton = document.getElementById("addNumberSubmit");
             const placeholder = document.getElementById("numberPlaceholder");
+            const outsidePlaceholder = document.getElementById("numberPlaceholderOutside");
             if (!hiddenInput || !container) return;
 
-            hiddenInput.value = selectedNumbers.join("+");
+            const expanded = [];
+            selectedNumbers.forEach(number => {
+                const count = selectedNumberCounts.get(number) ?? 1;
+                for (let i = 0; i < count; i++) expanded.push(number);
+            });
+            hiddenInput.value = expanded.join("+");
             container.innerHTML = "";
+            if (outsideContainer) outsideContainer.innerHTML = "";
 
             selectedNumbers.forEach(number => {
+                const count = selectedNumberCounts.get(number) ?? 1;
                 const chip = document.createElement("button");
                 chip.type = "button";
-                chip.className = "btn btn-sm btn-primary";
-                chip.textContent = `${number} ×`;
+                chip.className = "numbers-chip";
+                chip.innerHTML = `<span>${number}</span><span class="numbers-chip-badge">${count}</span>`;
                 chip.onclick = function () {
-                    selectedNumbers = selectedNumbers.filter(x => x !== number);
+                    const current = selectedNumberCounts.get(number) ?? 1;
+                    if (current > 1) {
+                        selectedNumberCounts.set(number, current - 1);
+                    } else {
+                        selectedNumberCounts.delete(number);
+                        selectedNumbers = selectedNumbers.filter(x => x !== number);
+                    }
                     syncNumberPalette();
                     renderSelectedNumbers();
                 };
                 container.appendChild(chip);
+                if (outsideContainer) {
+                    const outsideChip = chip.cloneNode(true);
+                    outsideChip.onclick = chip.onclick;
+                    outsideContainer.appendChild(outsideChip);
+                }
             });
 
             const hasSelection = selectedNumbers.length > 0;
             if (placeholder) {
                 placeholder.style.display = hasSelection ? "none" : "inline";
             }
+            if (outsidePlaceholder) {
+                outsidePlaceholder.style.display = hasSelection ? "none" : "inline";
+            }
             if (feedback) feedback.textContent = hasSelection ? "" : "Selecciona al menos un número.";
             if (submitButton) submitButton.disabled = !hasSelection;
+        }
+
+        function addOrIncrementSelection(value) {
+            if (!selectedNumbers.includes(value)) {
+                selectedNumbers.push(value);
+                selectedNumbers.sort();
+            }
+            selectedNumberCounts.set(value, (selectedNumberCounts.get(value) ?? 0) + 1);
         }
 
         function syncNumberPalette() {
             const buttons = document.querySelectorAll(".number-cell");
             buttons.forEach(btn => {
                 const value = btn.dataset.value;
+                const count = selectedNumberCounts.get(value) ?? 0;
                 btn.classList.toggle("btn-success", selectedNumbers.includes(value));
                 btn.classList.toggle("btn-outline-secondary", !selectedNumbers.includes(value));
+                let badge = btn.querySelector(".number-cell-badge");
+                if (count > 0) {
+                    if (!badge) {
+                        badge = document.createElement("span");
+                        badge.className = "number-cell-badge";
+                        btn.appendChild(badge);
+                    }
+                    badge.textContent = String(count);
+                } else if (badge) {
+                    badge.remove();
+                }
             });
         }
 
         function toggleNumberSelection(value) {
-            if (selectedNumbers.includes(value)) {
-                selectedNumbers = selectedNumbers.filter(x => x !== value);
-            } else {
-                selectedNumbers.push(value);
-                selectedNumbers.sort();
-            }
+            addOrIncrementSelection(value);
             syncNumberPalette();
             renderSelectedNumbers();
         }
 
+        function applyNumberSelection(value) {
+            if (dragTouchedValues.has(value)) return;
+            dragTouchedValues.add(value);
+            addOrIncrementSelection(value);
+            syncNumberPalette();
+            renderSelectedNumbers();
+        }
+
+        function bindGridDragSelection() {
+            const grid = document.getElementById("numberGrid");
+            if (!grid) return;
+            grid.addEventListener("mousedown", function (e) {
+                const cell = e.target.closest(".number-cell");
+                if (!cell) return;
+                e.preventDefault();
+                isDraggingNumbers = true;
+                dragTouchedValues = new Set();
+                applyNumberSelection(cell.dataset.value);
+            });
+            grid.addEventListener("mouseover", function (e) {
+                if (!isDraggingNumbers) return;
+                const cell = e.target.closest(".number-cell");
+                if (!cell) return;
+                applyNumberSelection(cell.dataset.value);
+            });
+            document.addEventListener("mouseup", function () {
+                isDraggingNumbers = false;
+                dragTouchedValues = new Set();
+            });
+        }
+
         function clearSelectedNumbers() {
             selectedNumbers = [];
+            selectedNumberCounts.clear();
+            appliedRuleValues.clear();
+            appliedAdvancedValues.clear();
+            syncRuleButtons();
+            syncAdvancedButtons();
             syncNumberPalette();
             renderSelectedNumbers();
         }
@@ -278,11 +357,127 @@
             const union = new Set(selectedNumbers);
             values.forEach(v => union.add(v));
             selectedNumbers = Array.from(union).sort();
+            values.forEach(v => selectedNumberCounts.set(v, (selectedNumberCounts.get(v) ?? 0) + 1));
             syncNumberPalette();
             renderSelectedNumbers();
         }
 
-        function selectRange() {
+        function removeValues(values) {
+            values.forEach(value => {
+                const current = selectedNumberCounts.get(value) ?? 0;
+                if (current > 1) {
+                    selectedNumberCounts.set(value, current - 1);
+                } else {
+                    selectedNumberCounts.delete(value);
+                    selectedNumbers = selectedNumbers.filter(v => v !== value);
+                }
+            });
+            syncNumberPalette();
+            renderSelectedNumbers();
+        }
+
+        function explodeDigitChunk(chunk) {
+            if (!chunk) return [];
+
+            if (chunk.length <= 2) {
+                const value = parseInt(chunk, 10);
+                return Number.isNaN(value) || value < 0 || value > 99 ? [] : [padNumber(value)];
+            }
+
+            const normalized = chunk.length % 2 === 0 ? chunk : `0${chunk}`;
+            const values = [];
+            for (let i = 0; i < normalized.length; i += 2) {
+                const pair = normalized.slice(i, i + 2);
+                const value = parseInt(pair, 10);
+                if (!Number.isNaN(value) && value >= 0 && value <= 99) {
+                    values.push(padNumber(value));
+                }
+            }
+            return values;
+        }
+
+        function parseNumbersFromText(raw) {
+            if (!raw) return { unique: [], expanded: [] };
+            const chunks = raw.split("+").map(x => x.trim()).filter(Boolean);
+            const unique = new Set();
+            const expanded = [];
+
+            chunks.forEach(chunk => {
+                explodeDigitChunk(chunk).forEach(value => {
+                    unique.add(value);
+                    expanded.push(value);
+                });
+            });
+
+            return { unique: Array.from(unique).sort(), expanded };
+        }
+
+        function applyPastedNumbers(replaceSelection) {
+            const input = document.getElementById("bulkNumbersInput");
+            const feedback = document.getElementById("numberFeedback");
+            if (!input) return;
+
+            const parsed = parseNumbersFromText(input.value);
+            if (!parsed.unique.length) {
+                if (feedback) feedback.textContent = "No se encontraron números válidos. Usa valores de 0 a 99.";
+                return;
+            }
+
+            if (replaceSelection) {
+                selectedNumbers = parsed.unique;
+                selectedNumberCounts.clear();
+                parsed.expanded.forEach(v => selectedNumberCounts.set(v, (selectedNumberCounts.get(v) ?? 0) + 1));
+                syncNumberPalette();
+                renderSelectedNumbers();
+            } else {
+                addUniqueValues(parsed.expanded);
+            }
+
+            if (feedback) feedback.textContent = `${parsed.expanded.length} número(s) procesado(s) desde texto.`;
+
+        }
+
+        function clearBulkNumbersInput() {
+            const input = document.getElementById("bulkNumbersInput");
+            const feedback = document.getElementById("numberFeedback");
+            if (input) input.value = "";
+            if (feedback) feedback.textContent = "";
+        }
+
+        function syncAdvancedButtons() {
+            const entries = [
+                ["range", "rangeApplyButton"],
+                ["startsWith", "startsWithApplyButton"],
+                ["endsWith", "endsWithApplyButton"]
+            ];
+            entries.forEach(([key, buttonId]) => {
+                const button = document.getElementById(buttonId);
+                if (!button) return;
+                button.textContent = appliedAdvancedValues.has(key) ? "Quitar" : "Aplicar";
+            });
+        }
+
+        function applyOrToggleAdvanced(key, valuesFactory) {
+            const feedback = document.getElementById("numberFeedback");
+            const existing = appliedAdvancedValues.get(key);
+            const nextValues = valuesFactory();
+            if (!nextValues) return false;
+
+            if (existing && existing.signature === nextValues.signature) {
+                removeValues(existing.values);
+                appliedAdvancedValues.delete(key);
+                if (feedback) feedback.textContent = "Se quitó la selección aplicada.";
+            } else {
+                if (existing) removeValues(existing.values);
+                addUniqueValues(nextValues.values);
+                appliedAdvancedValues.set(key, nextValues);
+                if (feedback) feedback.textContent = "Selección aplicada.";
+            }
+            syncAdvancedButtons();
+            return true;
+        }
+
+        function applyOrToggleRange() {
             const startInput = document.getElementById("rangeStart");
             const endInput = document.getElementById("rangeEnd");
             const feedback = document.getElementById("numberFeedback");
@@ -298,7 +493,10 @@
 
             const values = [];
             for (let i = start; i <= end; i++) values.push(padNumber(i));
-            addUniqueValues(values);
+            applyOrToggleAdvanced("range", () => ({
+                signature: `${start}-${end}`,
+                values
+            }));
         }
 
         function isPrime(number) {
@@ -309,20 +507,43 @@
             return true;
         }
 
-        function selectByRule(rule, digit = null) {
+        function getValuesByRule(rule, digit = null) {
             const values = [];
             for (let i = 0; i < 100; i++) {
                 const value = padNumber(i);
                 if (rule === "even" && i % 2 === 0) values.push(value);
                 if (rule === "odd" && i % 2 !== 0) values.push(value);
                 if (rule === "prime" && isPrime(i)) values.push(value);
+                if (rule === "m5" && i % 5 === 0) values.push(value);
                 if (rule === "startsWith" && value.startsWith(String(digit))) values.push(value);
                 if (rule === "endsWith" && value.endsWith(String(digit))) values.push(value);
             }
-            addUniqueValues(values);
+            return values;
         }
 
-        function applyStartsWithDigit() {
+        function syncRuleButtons() {
+            ["even", "odd", "prime", "m5"].forEach(rule => {
+                const button = document.getElementById(`rule-${rule}`);
+                if (!button) return;
+                const isActive = appliedRuleValues.has(rule);
+                button.classList.toggle("btn-primary", isActive);
+                button.classList.toggle("btn-outline-primary", !isActive);
+            });
+        }
+
+        function toggleRuleSelection(rule) {
+            if (appliedRuleValues.has(rule)) {
+                removeValues(appliedRuleValues.get(rule));
+                appliedRuleValues.delete(rule);
+            } else {
+                const values = getValuesByRule(rule);
+                addUniqueValues(values);
+                appliedRuleValues.set(rule, values);
+            }
+            syncRuleButtons();
+        }
+
+        function applyOrToggleStartsWithDigit() {
             const input = document.getElementById("startsWithDigit");
             const feedback = document.getElementById("numberFeedback");
             if (!input) return;
@@ -331,10 +552,13 @@
                 if (feedback) feedback.textContent = "Para 'Inician en', usa un dígito de 0 a 9.";
                 return;
             }
-            selectByRule("startsWith", digit);
+            applyOrToggleAdvanced("startsWith", () => ({
+                signature: String(digit),
+                values: getValuesByRule("startsWith", digit)
+            }));
         }
 
-        function applyEndsWithDigit() {
+        function applyOrToggleEndsWithDigit() {
             const input = document.getElementById("endsWithDigit");
             const feedback = document.getElementById("numberFeedback");
             if (!input) return;
@@ -343,7 +567,46 @@
                 if (feedback) feedback.textContent = "Para 'Terminan en', usa un dígito de 0 a 9.";
                 return;
             }
-            selectByRule("endsWith", digit);
+            applyOrToggleAdvanced("endsWith", () => ({
+                signature: String(digit),
+                values: getValuesByRule("endsWith", digit)
+            }));
+        }
+
+        function pickRandomNumbers() {
+            const countInput = document.getElementById("randomCount");
+            const feedback = document.getElementById("numberFeedback");
+            const count = parseInt(countInput?.value || "", 10);
+
+            if (Number.isNaN(count) || count < 1 || count > 100) {
+                if (feedback) feedback.textContent = "Para A Gallo Tapado usa una cantidad entre 1 y 100.";
+                return;
+            }
+
+            const pool = [];
+            for (let i = 0; i < 100; i++) pool.push(padNumber(i));
+            for (let i = pool.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [pool[i], pool[j]] = [pool[j], pool[i]];
+            }
+            selectedNumbers = pool.slice(0, count).sort();
+            selectedNumberCounts.clear();
+            selectedNumbers.forEach(v => selectedNumberCounts.set(v, 1));
+            appliedRuleValues.clear();
+            appliedAdvancedValues.clear();
+            syncRuleButtons();
+            syncAdvancedButtons();
+            syncNumberPalette();
+            renderSelectedNumbers();
+            if (feedback) feedback.textContent = `Se seleccionaron ${count} número(s) al azar (reemplazando la selección actual).`;
+        }
+
+        function clearRandomCount() {
+            const countInput = document.getElementById("randomCount");
+            const feedback = document.getElementById("numberFeedback");
+            if (countInput) countInput.value = "";
+            clearSelectedNumbers();
+            if (feedback) feedback.textContent = "";
         }
 
         function toggleNumberPalette() {
@@ -363,7 +626,6 @@
                 button.dataset.value = value;
                 button.className = "btn btn-sm btn-outline-secondary number-cell";
                 button.textContent = value;
-                button.style.minWidth = "48px";
                 button.onclick = function () { toggleNumberSelection(value); };
                 grid.appendChild(button);
             }
@@ -371,9 +633,28 @@
 
         $(document).ready(function () {
             const numberInput = document.getElementById('number');
+            const bulkInput = document.getElementById('bulkNumbersInput');
             if (numberInput) {
                 buildNumberGrid();
+                bindGridDragSelection();
                 renderSelectedNumbers();
+                syncRuleButtons();
+                syncAdvancedButtons();
+            }
+            if (bulkInput) {
+                bulkInput.addEventListener("input", function () {
+                    const digits = (bulkInput.value.match(/\d/g) || []).join("");
+                    const groups = [];
+                    const pairLimit = Math.floor(digits.length / 2) * 2;
+                    for (let i = 0; i < pairLimit; i += 2) {
+                        groups.push(digits.slice(i, i + 2));
+                    }
+                    const remainder = digits.slice(pairLimit);
+                    if (remainder.length === 1) {
+                        groups.push(`0${remainder}`);
+                    }
+                    bulkInput.value = groups.join("+");
+                });
             }
 
             $('#addNumberForm').submit(function (e) {

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -7,6 +7,16 @@
 
 <hr />
 
+<style>
+    .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
+    .number-grid .number-cell { position: relative; width:100%; min-width:0 !important; padding: .35rem .1rem; font-size: .72rem; line-height: 1.1; border-radius: 12px; }
+    .numbers-summary { min-height: 44px; }
+    .numbers-modal-trigger { white-space: nowrap; }
+    .numbers-chip { border: 0; background: #f2f4f8; color: #1f2937; border-radius: 999px; padding: .25rem .35rem .25rem .65rem; font-size: .78rem; display:inline-flex; align-items:center; gap:.35rem; }
+    .numbers-chip-badge { background:#0d6efd; color:#fff; border-radius:999px; font-size:.72rem; font-weight:700; min-width:26px; text-align:center; padding:.1rem .45rem; }
+    .number-cell-badge { position:absolute; top:2px; right:2px; background:#0d6efd; color:#fff; border-radius:999px; font-size:.62rem; line-height:1; padding:.15rem .3rem; min-width:20px; text-align:center; }
+</style>
+
 <form asp-action="Add" id="addNumberForm">
     <div class="row g-3">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -23,61 +33,19 @@
                 <span asp-validation-for="Busted" class="text-danger"></span>
             </div>
         }
-        <div class="form-group col-md-6">
+        <div class="form-group col-md-7">
             <label asp-for="Value" class="control-label">Números</label>
             <input asp-for="Value" id="number" type="hidden" />
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm" id="selectedNumbersInputLike">
-                <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
-                <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+            <div class="border rounded bg-white p-2 mb-2 shadow-sm numbers-summary">
+                <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainerOutside"></div>
+                <small id="numberPlaceholderOutside" class="text-muted">Aún no has seleccionado números</small>
             </div>
-            <small class="form-text text-muted d-block mb-2">Selecciona números tocando los botones o usa una regla rápida.</small>
             <div class="d-flex align-items-center gap-2 mb-2">
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleNumberPalette()">
-                    Mostrar/Ocultar selector
+                <button type="button" class="btn btn-sm btn-outline-primary numbers-modal-trigger" data-bs-toggle="modal" data-bs-target="#numbersModal" title="Abrir selector de números">
+                    <span class="material-icons" style="font-size:16px;vertical-align:text-bottom;">grid_view</span>
+                    Gestionar números
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger" onclick="clearSelectedNumbers()">
-                    Limpiar selección
-                </button>
-            </div>
-            <div class="border rounded bg-white p-2 mb-2 shadow-sm">
-                <div class="row g-2 align-items-end">
-                    <div class="col-md-5">
-                        <label class="form-label mb-1">Rango consecutivo</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
-                            <span class="input-group-text">a</span>
-                            <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
-                            <button type="button" class="btn btn-outline-primary" onclick="selectRange()">Aplicar</button>
-                        </div>
-                    </div>
-                    <div class="col-md-7">
-                        <label class="form-label mb-1">Reglas rápidas</label>
-                        <div class="d-flex flex-wrap gap-1">
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('even')">Pares</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('odd')">Impares</button>
-                            <button type="button" class="btn btn-sm btn-outline-primary" onclick="selectByRule('prime')">Primos</button>
-                        </div>
-                    </div>
-                </div>
-                <div class="row g-2 mt-1">
-                    <div class="col-md-6">
-                        <label class="form-label mb-1">Inician en</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                            <button type="button" class="btn btn-outline-secondary" onclick="applyStartsWithDigit()">Aplicar</button>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <label class="form-label mb-1">Terminan en</label>
-                        <div class="input-group input-group-sm">
-                            <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
-                            <button type="button" class="btn btn-outline-secondary" onclick="applyEndsWithDigit()">Aplicar</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div id="numberPalette" class="border rounded bg-white p-2 shadow-sm" style="max-height: 240px; overflow-y: auto;">
-                <div id="numberGrid" class="d-flex flex-wrap gap-1"></div>
+                <small class="text-muted">Aquí puedes elegir números, aplicar filtros o pegar listas.</small>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
             <span asp-validation-for="Value" class="text-danger"></span>
@@ -91,3 +59,105 @@
 </form>
 
 <hr />
+
+<div class="modal fade" id="numbersModal" tabindex="-1" aria-labelledby="numbersModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-fullscreen-lg-down modal-xl modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="numbersModalLabel">Gestión de números</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body p-2 p-lg-3">
+        <div class="row g-3">
+            <div class="col-lg-7">
+                <div class="border rounded bg-white p-2 shadow-sm mb-2">
+                    <div class="d-flex flex-wrap gap-1" id="selectedNumbersContainer"></div>
+                    <small id="numberPlaceholder" class="text-muted">Aún no has seleccionado números</small>
+                </div>
+                <div class="border rounded bg-white p-2 shadow-sm mb-3">
+                    <div id="numberPalette">
+                        <div id="numberGrid" class="number-grid"></div>
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-danger mt-2" onclick="clearSelectedNumbers()">Limpiar selección</button>
+                </div>
+            </div>
+            <div class="col-lg-5">
+                <div class="accordion" id="numbersAccordion">
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingRules">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRules" aria-expanded="false" aria-controls="collapseRules">
+                                Reglas y filtros rápidos
+                            </button>
+                        </h2>
+                        <div id="collapseRules" class="accordion-collapse collapse" aria-labelledby="headingRules" data-bs-parent="#numbersAccordion">
+                            <div class="accordion-body">
+                                <div class="row g-2 align-items-end">
+                            <div class="col-12">
+                                <label class="form-label mb-1">Rango consecutivo</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="rangeStart" class="form-control" min="0" max="99" placeholder="00" />
+                                    <span class="input-group-text">a</span>
+                                    <input type="number" id="rangeEnd" class="form-control" min="0" max="99" placeholder="10" />
+                                    <button type="button" id="rangeApplyButton" class="btn btn-outline-primary" onclick="applyOrToggleRange()">Aplicar</button>
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label mb-1">Reglas rápidas</label>
+                                <div class="d-flex flex-wrap gap-1">
+                                    <button type="button" id="rule-even" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('even')">Pares</button>
+                                    <button type="button" id="rule-odd" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('odd')">Impares</button>
+                                    <button type="button" id="rule-prime" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('prime')">Primos</button>
+                                    <button type="button" id="rule-m5" class="btn btn-sm btn-outline-primary" onclick="toggleRuleSelection('m5')">Múltiplos 5</button>
+                                </div>
+                            </div>
+                            <div class="col-12 col-md-6">
+                                <label class="form-label mb-1">Inician en</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="startsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                    <button type="button" id="startsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleStartsWithDigit()">Aplicar</button>
+                                </div>
+                            </div>
+                            <div class="col-12 col-md-6">
+                                <label class="form-label mb-1">Terminan en</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="endsWithDigit" class="form-control" min="0" max="9" placeholder="0-9" />
+                                    <button type="button" id="endsWithApplyButton" class="btn btn-outline-secondary" onclick="applyOrToggleEndsWithDigit()">Aplicar</button>
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label mb-1">A Gallo Tapado</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" id="randomCount" class="form-control" min="1" max="100" placeholder="Cantidad (1-100)" />
+                                    <button type="button" class="btn btn-outline-dark" onclick="pickRandomNumbers()">Elegir al azar</button>
+                                    <button type="button" class="btn btn-outline-secondary" onclick="clearRandomCount()">Limpiar</button>
+                                </div>
+                            </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingPaste">
+                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="true" aria-controls="collapsePaste">
+                                Copiar / pegar números
+                            </button>
+                        </h2>
+                        <div id="collapsePaste" class="accordion-collapse collapse show" aria-labelledby="headingPaste" data-bs-parent="#numbersAccordion">
+                            <div class="accordion-body">
+                            <label class="form-label mb-1">Pegar lista de números</label>
+                            <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: 00+01+78'></textarea>
+                            <small class="text-muted d-block mt-2">Solo dígitos. Se formatea automáticamente como 00+01+78.</small>
+                            <div class="d-flex flex-wrap gap-1 mt-2">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar</button>
+                                <button type="button" class="btn btn-sm btn-outline-primary" onclick="applyPastedNumbers(false)">Agregar</button>
+                                <button type="button" class="btn btn-sm btn-primary" onclick="applyPastedNumbers(true)">Reemplazar</button>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+      </div>
+  </div>
+</div>


### PR DESCRIPTION
### Motivation

- Make number selection more usable by adding a full-featured modal selector and a compact summary view. 
- Support multiple selections of the same number and surface counts in both the summary and the grid. 
- Provide faster selection workflows via drag-to-select, quick rules (even/odd/prime/multiples), paste-import and random picking.

### Description

- Reworked `_Add.cshtml` to replace the inline palette with a modal (`#numbersModal`) and add a compact outside summary area (`#selectedNumbersContainerOutside`) and CSS styles for grid, chips and badges. 
- Rewrote client-side logic in `Create.cshtml` to support per-number counts using `selectedNumberCounts`, expanded hidden input values, badges on number cells, and chip badges in the summary. 
- Added drag-to-select (`bindGridDragSelection`), bulk paste parsing (`parseNumbersFromText`, `applyPastedNumbers`), range/startsWith/endsWith toggles with apply/remove semantics (`applyOrToggleAdvanced`, `applyOrToggleRange`, `applyOrToggleStartsWithDigit`, `applyOrToggleEndsWithDigit`), rule toggles (`toggleRuleSelection`) and random pick (`pickRandomNumbers`). 
- Improved sync functions for UI state: `syncNumberPalette`, `renderSelectedNumbers`, `syncRuleButtons`, `syncAdvancedButtons`, plus helpers `explodeDigitChunk`, `addOrIncrementSelection`, `removeValues`, and grid renderer `buildNumberGrid`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c79612e083308d7253c703f933bb)