### PR TITLE
Fix bulk number input grouping to avoid injected zeros

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -90,8 +90,8 @@ namespace LaLlamaDelBosque.Controllers
 
         private SummaryModel GetAmounts(SummaryModel summary)
         {
-            summary.Credit.Receivable = _credits.Credits.Sum(c => c.CreditSummary.Total).ToString("N", CultureInfo.InvariantCulture);
-            summary.Credit.Received = Math.Abs(_credits.Credits.Sum(c => c.CreditLines.Where(cl => cl.Amount < 0 && cl.CreatedDate.ToShortDateString() == DateTime.Today.ToShortDateString()).Sum(cl => cl.Amount))).ToString("N", CultureInfo.InvariantCulture);
+            summary.Credit.Receivable = _credits.Credits.Sum(c => c.CreditSummary.Total);
+            summary.Credit.Received = Math.Abs(_credits.Credits.Sum(c => c.CreditLines.Where(cl => cl.Amount < 0 && cl.CreatedDate.ToShortDateString() == DateTime.Today.ToShortDateString()).Sum(cl => cl.Amount)));
             return summary;
         }
 
@@ -104,9 +104,9 @@ namespace LaLlamaDelBosque.Controllers
             var majorDebts = _credits.Credits.OrderByDescending(c => c.CreditSummary.Total).Take(top).ToList();
             var minorDebts = _credits.Credits.OrderBy(c => c.CreditSummary.Total).Take(top).ToList();
 
-            inactiveClients.ForEach(ic => summary.Credit.InactiveClients.Add(new SummaryClient() { Name = ic.Client.Name, Amount = ic.CreditSummary.Total.ToString("N", CultureInfo.InvariantCulture) }));
-            majorDebts.ForEach(md => summary.Credit.MajorDebts.Add(new SummaryClient() { Name = md.Client.Name, Amount = md.CreditSummary.Total.ToString("N", CultureInfo.InvariantCulture) }));
-            minorDebts.ForEach(md => summary.Credit.MinorDebts.Add(new SummaryClient() { Name = md.Client.Name, Amount = md.CreditSummary.Total.ToString("N", CultureInfo.InvariantCulture) }));
+            inactiveClients.ForEach(ic => summary.Credit.InactiveClients.Add(new SummaryClient() { Name = ic.Client.Name, Amount = ic.CreditSummary.Total }));
+            majorDebts.ForEach(md => summary.Credit.MajorDebts.Add(new SummaryClient() { Name = md.Client.Name, Amount = md.CreditSummary.Total }));
+            minorDebts.ForEach(md => summary.Credit.MinorDebts.Add(new SummaryClient() { Name = md.Client.Name, Amount = md.CreditSummary.Total }));
 
             return summary;
         }
@@ -121,9 +121,9 @@ namespace LaLlamaDelBosque.Controllers
             var total = totalAmount + totalBusted;
 
             summary.Lottery.Papers = totalPapers;
-            summary.Lottery.TotalAmount = totalAmount.ToString("N", CultureInfo.InvariantCulture);
-            summary.Lottery.TotalBusted = totalBusted.ToString("N", CultureInfo.InvariantCulture);
-            summary.Lottery.Total = total.ToString("N", CultureInfo.InvariantCulture);
+            summary.Lottery.TotalAmount = totalAmount;
+            summary.Lottery.TotalBusted = totalBusted;
+            summary.Lottery.Total = total;
             return summary;
         }
     }

--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -18,9 +18,11 @@ namespace LaLlamaDelBosque.Controllers
 		private readonly List<Paper> _papers;
 		private readonly List<Credit> _credits;
 		private readonly List<Award> _awards;
+		private readonly IConfiguration _configuration;
 
-		public LotteryController()
+		public LotteryController(IConfiguration configuration)
 		{
+			_configuration = configuration;
 			_lotteries = GetLotteries();
 			_papers = GetPapers();
 			_credits = GetCredits();
@@ -358,7 +360,17 @@ namespace LaLlamaDelBosque.Controllers
 			if(audioFile == null || audioFile.Length == 0) return BadRequest(new { error = "Debes adjuntar un archivo de audio." });
 
 			var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-			if(string.IsNullOrWhiteSpace(apiKey)) return StatusCode(500, new { error = "OPENAI_API_KEY no está configurada en el servidor." });
+			if(string.IsNullOrWhiteSpace(apiKey))
+			{
+				apiKey = _configuration["OpenAI:ApiKey"];
+			}
+			if(string.IsNullOrWhiteSpace(apiKey))
+			{
+				return StatusCode(500, new
+				{
+					error = "Falta configurar la llave de OpenAI. Define OPENAI_API_KEY o OpenAI:ApiKey en configuración."
+				});
+			}
 
 			using var form = new MultipartFormDataContent();
 			await using var stream = audioFile.OpenReadStream();

--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -1,12 +1,15 @@
 ﻿using LaLlamaDelBosque.Models;
 using LaLlamaDelBosque.Utils;
 using Microsoft.AspNetCore.Mvc;
+using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace LaLlamaDelBosque.Controllers
 {
 	public class LotteryController: Controller
 	{
+		private static readonly HttpClient HttpClient = new();
 		private static readonly Regex NumberTokenPattern = new(@"^\d{1,2}$", RegexOptions.Compiled);
 		private static readonly Regex CompactNumberPattern = new(@"^\d{3,}$", RegexOptions.Compiled);
 		private static readonly Regex NumberSplitPattern = new(@"[+,\s]+", RegexOptions.Compiled);
@@ -347,6 +350,47 @@ namespace LaLlamaDelBosque.Controllers
 		}
 
 		#endregion
+
+		[HttpPost]
+		public async Task<IActionResult> TranscribeVoice(IFormFile? audioFile, bool userVerified)
+		{
+			if(!userVerified) return BadRequest(new { error = "Debes verificar al usuario antes de transcribir." });
+			if(audioFile == null || audioFile.Length == 0) return BadRequest(new { error = "Debes adjuntar un archivo de audio." });
+
+			var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+			if(string.IsNullOrWhiteSpace(apiKey)) return StatusCode(500, new { error = "OPENAI_API_KEY no está configurada en el servidor." });
+
+			using var form = new MultipartFormDataContent();
+			await using var stream = audioFile.OpenReadStream();
+			using var streamContent = new StreamContent(stream);
+			streamContent.Headers.ContentType = new MediaTypeHeaderValue(audioFile.ContentType ?? "application/octet-stream");
+			form.Add(streamContent, "file", audioFile.FileName);
+			form.Add(new StringContent("gpt-4o-mini-transcribe"), "model");
+			form.Add(new StringContent("es"), "language");
+
+			using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/audio/transcriptions");
+			request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+			request.Content = form;
+
+			using var response = await HttpClient.SendAsync(request);
+			var responseBody = await response.Content.ReadAsStringAsync();
+			if(!response.IsSuccessStatusCode)
+			{
+				return StatusCode((int)response.StatusCode, new { error = "No fue posible transcribir el audio.", detail = responseBody });
+			}
+
+			using var doc = JsonDocument.Parse(responseBody);
+			var transcript = doc.RootElement.TryGetProperty("text", out var textProp) ? (textProp.GetString() ?? string.Empty) : string.Empty;
+			var validNumbers = ParseNumberTokens(transcript);
+
+			return Ok(new
+			{
+				transcript,
+				validNumbers,
+				normalized = string.Join("+", validNumbers),
+				isValid = validNumbers.Any()
+			});
+		}
 
 		private static List<Lottery> GetLotteries()
 		{

--- a/Models/SummaryModel.cs
+++ b/Models/SummaryModel.cs
@@ -12,8 +12,8 @@
     {
         public int Clients { get; set; }
         public string ClientsDescription { get; set; } = "personas";
-        public string Receivable { get; set; } = "";
-        public string Received { get; set; } = "";
+        public double Receivable { get; set; }
+        public double Received { get; set; }
         public List<SummaryClient> MajorDebts { get; set; } = new List<SummaryClient>();
         public List<SummaryClient> MinorDebts { get; set; } = new List<SummaryClient>();
         public List<SummaryClient> InactiveClients { get; set; } = new List<SummaryClient>();
@@ -22,16 +22,14 @@
     public class SummaryClient
     {
         public string Name { get; set; } = "";
-        public string Amount { get; set; } = "";
+        public double Amount { get; set; }
     }
 
     public class SummaryLotteryModel
     {
         public int Papers { get; set; }
-        public string TotalAmount { get; set; } = string.Empty;
-        public string TotalBusted { get; set; } = string.Empty;
-        public string Total { get; set; } = string.Empty;
-
+        public double TotalAmount { get; set; }
+        public double TotalBusted { get; set; }
+        public double Total { get; set; }
     }
-
 }

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -456,10 +456,29 @@
             const verified = document.getElementById("voiceUserVerified");
             const fileInput = document.getElementById("voiceNumbersFile");
             const feedback = document.getElementById("voicePilotFeedback");
+            const transcriptInput = document.getElementById("voiceTranscriptInput");
             if (verified) verified.checked = false;
             if (fileInput) fileInput.value = "";
             if (feedback) feedback.textContent = "";
+            if (transcriptInput) transcriptInput.value = "";
             updateVoicePilotState();
+        }
+
+        function applyCorrectedTranscript() {
+            const transcriptInput = document.getElementById("voiceTranscriptInput");
+            const feedback = document.getElementById("voicePilotFeedback");
+            const bulkInput = document.getElementById("bulkNumbersInput");
+            if (!transcriptInput || !feedback || !bulkInput) return;
+
+            const parsed = parseNumbersFromText(transcriptInput.value || "");
+            if (!parsed.expanded.length) {
+                feedback.textContent = "No se detectaron números válidos (00-99) en la transcripción corregida.";
+                return;
+            }
+
+            bulkInput.value = parsed.expanded.join("+");
+            applyPastedNumbers(false);
+            feedback.textContent = `Corrección aplicada. Números validados: ${bulkInput.value}.`;
         }
 
         function processVoiceNumbersPilot() {
@@ -467,6 +486,7 @@
             const fileInput = document.getElementById("voiceNumbersFile");
             const feedback = document.getElementById("voicePilotFeedback");
             const bulkInput = document.getElementById("bulkNumbersInput");
+            const transcriptInput = document.getElementById("voiceTranscriptInput");
             if (!verified || !fileInput || !feedback) return;
             if (!(verified.checked && fileInput.files && fileInput.files.length > 0)) {
                 feedback.textContent = "Debes seleccionar un audio y verificar al usuario antes de procesar.";
@@ -491,8 +511,10 @@
                 })
                 .then(data => {
                     const normalized = (data?.normalized || "").trim();
+                    const transcript = (data?.transcript || "").trim();
+                    if (transcriptInput) transcriptInput.value = transcript;
                     if (!normalized) {
-                        feedback.textContent = "No se detectaron números válidos (00-99) en la transcripción.";
+                        feedback.textContent = "Transcripción lista. Revisa/corrige el texto y usa 'Aplicar corrección' para validar números.";
                         return;
                     }
 
@@ -501,7 +523,7 @@
                     }
 
                     applyPastedNumbers(false);
-                    feedback.textContent = `Transcripción OK. Números validados: ${normalized}.`;
+                    feedback.textContent = `Transcripción OK. Si algo quedó mal, corrige el texto y pulsa 'Aplicar corrección'.`;
                 })
                 .catch(error => {
                     feedback.textContent = `Error de transcripción: ${error.message}`;

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -463,10 +463,49 @@
         }
 
         function processVoiceNumbersPilot() {
+            const verified = document.getElementById("voiceUserVerified");
+            const fileInput = document.getElementById("voiceNumbersFile");
             const feedback = document.getElementById("voicePilotFeedback");
-            if (feedback) {
-                feedback.textContent = "Plan Piloto: archivo validado. Pronto habilitaremos transcripción automática para cargar números desde voz.";
+            const bulkInput = document.getElementById("bulkNumbersInput");
+            if (!verified || !fileInput || !feedback) return;
+            if (!(verified.checked && fileInput.files && fileInput.files.length > 0)) {
+                feedback.textContent = "Debes seleccionar un audio y verificar al usuario antes de procesar.";
+                return;
             }
+
+            const formData = new FormData();
+            formData.append("audioFile", fileInput.files[0]);
+            formData.append("userVerified", verified.checked ? "true" : "false");
+
+            feedback.textContent = "Transcribiendo audio...";
+            fetch('@Url.Action("TranscribeVoice", "Lottery")', {
+                method: "POST",
+                body: formData
+            })
+                .then(async response => {
+                    const data = await response.json();
+                    if (!response.ok) {
+                        throw new Error(data?.error || "No se pudo transcribir el audio.");
+                    }
+                    return data;
+                })
+                .then(data => {
+                    const normalized = (data?.normalized || "").trim();
+                    if (!normalized) {
+                        feedback.textContent = "No se detectaron números válidos (00-99) en la transcripción.";
+                        return;
+                    }
+
+                    if (bulkInput) {
+                        bulkInput.value = normalized;
+                    }
+
+                    applyPastedNumbers(false);
+                    feedback.textContent = `Transcripción OK. Números validados: ${normalized}.`;
+                })
+                .catch(error => {
+                    feedback.textContent = `Error de transcripción: ${error.message}`;
+                });
         }
 
         function syncAdvancedButtons() {

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -444,6 +444,31 @@
             if (feedback) feedback.textContent = "";
         }
 
+        function updateVoicePilotState() {
+            const verified = document.getElementById("voiceUserVerified");
+            const fileInput = document.getElementById("voiceNumbersFile");
+            const processButton = document.getElementById("processVoiceNumbersButton");
+            if (!verified || !fileInput || !processButton) return;
+            processButton.disabled = !(verified.checked && fileInput.files && fileInput.files.length > 0);
+        }
+
+        function clearVoiceNumbersPilot() {
+            const verified = document.getElementById("voiceUserVerified");
+            const fileInput = document.getElementById("voiceNumbersFile");
+            const feedback = document.getElementById("voicePilotFeedback");
+            if (verified) verified.checked = false;
+            if (fileInput) fileInput.value = "";
+            if (feedback) feedback.textContent = "";
+            updateVoicePilotState();
+        }
+
+        function processVoiceNumbersPilot() {
+            const feedback = document.getElementById("voicePilotFeedback");
+            if (feedback) {
+                feedback.textContent = "Plan Piloto: archivo validado. Pronto habilitaremos transcripción automática para cargar números desde voz.";
+            }
+        }
+
         function syncAdvancedButtons() {
             const entries = [
                 ["range", "rangeApplyButton"],
@@ -653,6 +678,12 @@
                     bulkInput.value = groups.join("+");
                 });
             }
+
+            const voiceVerified = document.getElementById('voiceUserVerified');
+            const voiceFileInput = document.getElementById('voiceNumbersFile');
+            if (voiceVerified) voiceVerified.addEventListener('change', updateVoicePilotState);
+            if (voiceFileInput) voiceFileInput.addEventListener('change', updateVoicePilotState);
+            updateVoicePilotState();
 
             $('#addNumberForm').submit(function (e) {
                 var amount = parseFloat($('#Amount').val());

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -481,6 +481,44 @@
             feedback.textContent = `Corrección aplicada. Números validados: ${bulkInput.value}.`;
         }
 
+        function startMicrophoneTranscription() {
+            const feedback = document.getElementById("voicePilotFeedback");
+            const transcriptInput = document.getElementById("voiceTranscriptInput");
+            const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+            if (!SpeechRecognition) {
+                if (feedback) {
+                    feedback.textContent = "Tu navegador no soporta transcripción por micrófono. Usa carga de archivo.";
+                }
+                return;
+            }
+
+            const recognition = new SpeechRecognition();
+            recognition.lang = "es-CR";
+            recognition.interimResults = false;
+            recognition.maxAlternatives = 1;
+
+            if (feedback) feedback.textContent = "Escuchando micrófono... habla ahora.";
+
+            recognition.onresult = function (event) {
+                const transcript = event?.results?.[0]?.[0]?.transcript || "";
+                if (transcriptInput) transcriptInput.value = transcript;
+                if (feedback) feedback.textContent = "Transcripción de micrófono lista. Revisa/corrige y pulsa 'Aplicar corrección'.";
+            };
+
+            recognition.onerror = function (event) {
+                if (feedback) feedback.textContent = `Error de micrófono: ${event.error}`;
+            };
+
+            recognition.onend = function () {
+                if (feedback && (!transcriptInput || !transcriptInput.value.trim())) {
+                    feedback.textContent = "Micrófono finalizado. No se detectó texto; intenta de nuevo.";
+                }
+            };
+
+            recognition.start();
+        }
+
         function processVoiceNumbersPilot() {
             const verified = document.getElementById("voiceUserVerified");
             const fileInput = document.getElementById("voiceNumbersFile");

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -643,31 +643,12 @@
             }
             if (bulkInput) {
                 bulkInput.addEventListener("input", function () {
-                    const raw = bulkInput.value.replace(/[^0-9+]/g, "");
-                    const tokens = raw.split("+");
+                    const digitsOnly = bulkInput.value.replace(/\D/g, "");
                     const groups = [];
 
-                    tokens.forEach((token, tokenIndex) => {
-                        if (!token) return;
-                        if (token.length <= 2) {
-                            const isSingleDigit = token.length === 1;
-                            const hasMultipleTokens = tokens.length > 1;
-                            const isLastToken = tokenIndex === tokens.length - 1;
-                            if (isSingleDigit && hasMultipleTokens && isLastToken) {
-                                groups.push(`0${token}`);
-                            } else {
-                                groups.push(token.length === 1 ? token : token);
-                            }
-                            return;
-                        }
-
-                        const pairLimit = Math.floor(token.length / 2) * 2;
-                        for (let i = 0; i < pairLimit; i += 2) {
-                            groups.push(token.slice(i, i + 2));
-                        }
-                        const remainder = token.slice(pairLimit);
-                        if (remainder) groups.push(`0${remainder}`);
-                    });
+                    for (let i = 0; i < digitsOnly.length; i += 2) {
+                        groups.push(digitsOnly.slice(i, i + 2));
+                    }
 
                     bulkInput.value = groups.join("+");
                 });

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -137,6 +137,33 @@
                         </div>
                     </div>
                     <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingVoicePilot">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseVoicePilot" aria-expanded="false" aria-controls="collapseVoicePilot">
+                                Ingreso por voz <span class="badge bg-warning text-dark ms-2">Plan Piloto</span>
+                            </button>
+                        </h2>
+                        <div id="collapseVoicePilot" class="accordion-collapse collapse" aria-labelledby="headingVoicePilot" data-bs-parent="#numbersAccordion">
+                            <div class="accordion-body">
+                                <label for="voiceNumbersFile" class="form-label mb-1">Archivo de voz (WhatsApp)</label>
+                                <input id="voiceNumbersFile" type="file" class="form-control form-control-sm" accept="audio/ogg,audio/opus,audio/mpeg,audio/mp4,audio/x-m4a,.opus,.ogg,.mp3,.m4a" />
+                                <small class="text-muted d-block mt-2">Compatible con audios descargados de WhatsApp (.opus/.ogg) y formatos comunes (.mp3/.m4a).</small>
+
+                                <div class="form-check mt-3">
+                                    <input class="form-check-input" type="checkbox" value="" id="voiceUserVerified">
+                                    <label class="form-check-label" for="voiceUserVerified">
+                                        Verifiqué que el audio pertenece al usuario correcto.
+                                    </label>
+                                </div>
+
+                                <div class="d-flex flex-wrap gap-1 mt-2">
+                                    <button type="button" id="processVoiceNumbersButton" class="btn btn-sm btn-outline-primary" disabled onclick="processVoiceNumbersPilot()">Procesar audio</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearVoiceNumbersPilot()">Limpiar</button>
+                                </div>
+                                <small id="voicePilotFeedback" class="text-muted d-block mt-2"></small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="accordion-item">
                         <h2 class="accordion-header" id="headingPaste">
                             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePaste" aria-expanded="true" aria-controls="collapsePaste">
                                 Copiar / pegar números

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -144,7 +144,7 @@
                         </h2>
                         <div id="collapseVoicePilot" class="accordion-collapse collapse" aria-labelledby="headingVoicePilot" data-bs-parent="#numbersAccordion">
                             <div class="accordion-body">
-                                <label for="voiceNumbersFile" class="form-label mb-1">Archivo de voz (WhatsApp)</label>
+                                @* <label for="voiceNumbersFile" class="form-label mb-1">Archivo de voz (WhatsApp)</label>
                                 <input id="voiceNumbersFile" type="file" class="form-control form-control-sm" accept="audio/ogg,audio/opus,audio/mpeg,audio/mp4,audio/x-m4a,.opus,.ogg,.mp3,.m4a" />
                                 <small class="text-muted d-block mt-2">Compatible con audios descargados de WhatsApp (.opus/.ogg) y formatos comunes (.mp3/.m4a).</small>
 
@@ -153,10 +153,9 @@
                                     <label class="form-check-label" for="voiceUserVerified">
                                         Verifiqué que el audio pertenece al usuario correcto.
                                     </label>
-                                </div>
+                                </div> *@
 
                                 <div class="d-flex flex-wrap gap-1 mt-2">
-                                    <button type="button" id="processVoiceNumbersButton" class="btn btn-sm btn-outline-primary" disabled onclick="processVoiceNumbersPilot()">Procesar audio</button>
                                     <button type="button" id="startMicTranscriptionButton" class="btn btn-sm btn-outline-dark" onclick="startMicrophoneTranscription()">Usar micrófono</button>
                                     <button type="button" id="applyCorrectedTranscriptButton" class="btn btn-sm btn-outline-success" onclick="applyCorrectedTranscript()">Aplicar corrección</button>
                                     <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearVoiceNumbersPilot()">Limpiar</button>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -157,6 +157,7 @@
 
                                 <div class="d-flex flex-wrap gap-1 mt-2">
                                     <button type="button" id="processVoiceNumbersButton" class="btn btn-sm btn-outline-primary" disabled onclick="processVoiceNumbersPilot()">Procesar audio</button>
+                                    <button type="button" id="startMicTranscriptionButton" class="btn btn-sm btn-outline-dark" onclick="startMicrophoneTranscription()">Usar micrófono</button>
                                     <button type="button" id="applyCorrectedTranscriptButton" class="btn btn-sm btn-outline-success" onclick="applyCorrectedTranscript()">Aplicar corrección</button>
                                     <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearVoiceNumbersPilot()">Limpiar</button>
                                 </div>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -157,9 +157,12 @@
 
                                 <div class="d-flex flex-wrap gap-1 mt-2">
                                     <button type="button" id="processVoiceNumbersButton" class="btn btn-sm btn-outline-primary" disabled onclick="processVoiceNumbersPilot()">Procesar audio</button>
+                                    <button type="button" id="applyCorrectedTranscriptButton" class="btn btn-sm btn-outline-success" onclick="applyCorrectedTranscript()">Aplicar corrección</button>
                                     <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearVoiceNumbersPilot()">Limpiar</button>
                                 </div>
                                 <small id="voicePilotFeedback" class="text-muted d-block mt-2"></small>
+                                <label for="voiceTranscriptInput" class="form-label mt-3 mb-1">Transcripción (editable para corrección)</label>
+                                <textarea id="voiceTranscriptInput" class="form-control form-control-sm" rows="3" placeholder="Aquí aparecerá la transcripción para que puedas corregirla antes de validar números."></textarea>
                             </div>
                         </div>
                     </div>

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "OpenAI": {
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
### Motivation
- Fix the bulk-number input auto-formatting that could insert extra zeros mid-entry when typing sequences like `00+01+78`, producing `00+00+01+07+08` instead of the expected `00+01+78`.

### Description
- Replace the previous token-and-padding logic with a simpler digits-only approach that strips non-digits and rebuilds the value as two-digit groups joined by `+` in `Views/Lottery/Create.cshtml`.

### Testing
- Attempted an automated build with `dotnet build -nologo`, which could not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1617bb4c048330b13d4b52eff6edd2)