### PR TITLE
Validaciones en Create de Lottery: exigir sorteo, fecha y líneas válidas; prohibir reventado>monto

### DIFF
--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -245,7 +245,7 @@ namespace LaLlamaDelBosque.Controllers
 					SetPapers(_papers);
 				}
 				TempData.Put<Paper>("Paper", null);
-				return RedirectToAction(nameof(Print), new { ids = ids });
+				return RedirectToAction(nameof(Print), new { ids = string.Join(",", ids) });
 			}
 			catch(Exception ex)
 			{
@@ -253,9 +253,24 @@ namespace LaLlamaDelBosque.Controllers
 			}
 		}
 
-		public ActionResult Print(List<int>? ids = null, int? id = null)
+		public ActionResult Print(string? ids = null, int? id = null)
 		{
-			var selectedIds = (ids?.Any() == true) ? ids : (id.HasValue ? new List<int> { id.Value } : null);
+			var selectedIds = new List<int>();
+			if(!string.IsNullOrWhiteSpace(ids))
+			{
+				selectedIds = ids
+					.Split(",", StringSplitOptions.RemoveEmptyEntries)
+					.Select(x => int.TryParse(x.Trim(), out var parsed) ? parsed : (int?)null)
+					.Where(x => x.HasValue)
+					.Select(x => x!.Value)
+					.Distinct()
+					.ToList();
+			}
+			else if(id.HasValue)
+			{
+				selectedIds.Add(id.Value);
+			}
+
 			if(selectedIds == null || !selectedIds.Any()) return BadRequest("No se especificaron IDs válidos.");
 
 			var papers = _papers.Where(p => selectedIds.Contains(p.Id)).ToList();
@@ -266,7 +281,7 @@ namespace LaLlamaDelBosque.Controllers
 
 			ViewData["Date"] = DateTime.Now.ToShortDateString();
 			ViewData["Client"] = _credits.Select(c => c.Client).FirstOrDefault(c => c.Id == paper.ClientId)?.Name;
-			ViewData["Cant"] = selectedIds.Count;
+			ViewData["Cant"] = papers.Count;
 			ViewData["Ids"] = string.Join(", ", papers.Select(p => "#" + p.Id));
 
 			return View(paper);

--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -122,17 +122,30 @@ namespace LaLlamaDelBosque.Controllers
 		// POST: LotteryController/Save
 		[HttpPost]
 		[ValidateAntiForgeryToken]
-		public ActionResult Save(string? selectedLotteries, DateTime? drawDate, int? clientId, string? numbersDraftJson)
+		public ActionResult Save(List<string>? SelectedLotteries, string? selectedLotteries, DateTime? drawDate, int? clientId, string? numbersDraftJson)
 		{
 			try
 			{
 				var paper = TempData.Get<Paper>("Paper") ?? new Paper();
-				var selectedNames = (selectedLotteries ?? string.Empty)
-					.Split(",", StringSplitOptions.RemoveEmptyEntries)
-					.Select(x => x.Trim())
-					.Where(x => !string.IsNullOrWhiteSpace(x))
-					.Distinct()
-					.ToList();
+				var selectedNames = new List<string>();
+				if(SelectedLotteries is not null && SelectedLotteries.Any())
+				{
+					selectedNames = SelectedLotteries
+						.Select(x => x?.Trim())
+						.Where(x => !string.IsNullOrWhiteSpace(x))
+						.Select(x => x!)
+						.Distinct()
+						.ToList();
+				}
+				else if(!string.IsNullOrWhiteSpace(selectedLotteries))
+				{
+					selectedNames = selectedLotteries
+						.Split(",", StringSplitOptions.RemoveEmptyEntries)
+						.Select(x => x.Trim())
+						.Where(x => !string.IsNullOrWhiteSpace(x))
+						.Distinct()
+						.ToList();
+				}
 				if(selectedNames.Any())
 				{
 					paper.SelectedLotteries = selectedNames;

--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -122,18 +122,22 @@ namespace LaLlamaDelBosque.Controllers
 		// POST: LotteryController/Save
 		[HttpPost]
 		[ValidateAntiForgeryToken]
-		public ActionResult Save(List<string>? SelectedLotteries, string? selectedLotteries, DateTime? drawDate, int? clientId, string? numbersDraftJson)
+		public ActionResult Save(string? selectedLotteries, DateTime? drawDate, int? clientId, string? numbersDraftJson)
 		{
 			try
 			{
 				var paper = TempData.Get<Paper>("Paper") ?? new Paper();
 				var selectedNames = new List<string>();
-				if(SelectedLotteries is not null && SelectedLotteries.Any())
+
+				var selectedFromForm = Request.Form["SelectedLotteries"]
+					.Select(x => x?.Trim())
+					.Where(x => !string.IsNullOrWhiteSpace(x))
+					.Select(x => x!)
+					.ToList();
+
+				if(selectedFromForm.Any())
 				{
-					selectedNames = SelectedLotteries
-						.Select(x => x?.Trim())
-						.Where(x => !string.IsNullOrWhiteSpace(x))
-						.Select(x => x!)
+					selectedNames = selectedFromForm
 						.Distinct()
 						.ToList();
 				}

--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -163,6 +163,41 @@ namespace LaLlamaDelBosque.Controllers
 					}
 					catch { }
 				}
+
+				if(!selectedNames.Any())
+				{
+					TempData["ErrorMessage"] = "Debe seleccionar al menos un sorteo antes de crear el papelito.";
+					TempData.Put("Paper", paper);
+					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", selectedNames), dateString = drawDate?.ToString("yyyy-MM-dd"), clientId });
+				}
+
+				if(!drawDate.HasValue)
+				{
+					TempData["ErrorMessage"] = "La fecha de sorteo es obligatoria.";
+					TempData.Put("Paper", paper);
+					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", selectedNames), clientId });
+				}
+
+				var validNumbers = paper.Numbers
+					.Where(n => !string.IsNullOrWhiteSpace(n.Value))
+					.Where(n => n.Amount > 0 || n.Busted > 0)
+					.ToList();
+
+				if(!validNumbers.Any())
+				{
+					TempData["ErrorMessage"] = "Debe agregar al menos una línea de números con monto válido.";
+					TempData.Put("Paper", paper);
+					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", selectedNames), dateString = drawDate?.ToString("yyyy-MM-dd"), clientId });
+				}
+
+				if(validNumbers.Any(n => n.Busted > n.Amount))
+				{
+					TempData["ErrorMessage"] = "El reventado no puede ser mayor que el monto en ninguna línea.";
+					TempData.Put("Paper", paper);
+					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", selectedNames), dateString = drawDate?.ToString("yyyy-MM-dd"), clientId });
+				}
+
+				paper.Numbers = validNumbers;
 				var ids = new List<int>();
 				if(paper != null)
 				{

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -25,8 +25,11 @@
     </form>
 </div>
 <style>
+    .page-shell { max-width: 1240px; margin: 0 auto; }
+    .page-title { letter-spacing: -.02em; }
+    .section-caption { font-size: .82rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: #5f6b85; }
     .create-compact .card-body { padding: .85rem 1rem; }
-    .create-compact .form-group { margin-bottom: .25rem; }
+    .create-compact .form-group { margin-bottom: .2rem; }
     .create-compact .alert { margin-bottom: .6rem; padding: .55rem .75rem; }
     .create-compact .numbers-summary { min-height: 36px; }
     .numbers-workspace { background: linear-gradient(180deg,#f8fbff 0%, #ffffff 100%); border: 1px solid #e8eef7; border-radius: 16px; padding: 1rem; }
@@ -35,16 +38,23 @@
     .numbers-table-wrap .table thead th { background: #f4f8ff; border-bottom: 1px solid #e6edf7; font-size: .82rem; text-transform: uppercase; letter-spacing: .03em; }
     .numbers-table-wrap .table tbody tr:hover { background: #f8fbff; }
     .numbers-kpi { background: linear-gradient(135deg, #2463eb, #64b5f6); border-radius: 16px; }
+    .config-card { border-radius: 16px; border: 1px solid #ebeff5; }
+    .floating-actions { position: sticky; bottom: .6rem; z-index: 5; background: rgba(255,255,255,.9); backdrop-filter: blur(3px); border: 1px solid #e8eef7; border-radius: 12px; padding: .5rem; }
+    @@media (max-width: 767px) {
+        .floating-actions { position: static; }
+    }
 </style>
 
+<div class="page-shell">
 <form asp-action="Save" id="savePaperForm" class="create-compact">
     @if(TempData["ErrorMessage"] is string errorMessage && !string.IsNullOrWhiteSpace(errorMessage))
     {
         <div class="alert alert-danger shadow-sm">@errorMessage</div>
     }
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-    <div class="card shadow-sm border-0 mb-3">
+    <div class="card shadow-sm border-0 mb-3 config-card">
         <div class="card-body">
+            <div class="section-caption mb-2">Configuración del papelito</div>
             <div class="row g-3">
                 <div class="form-group col-md-2">
                     <label asp-for="Id" class="control-label fw-semibold">Papelito</label>
@@ -112,7 +122,7 @@
     </div>
     <input type="hidden" id="selectedLotteriesHidden" name="selectedLotteries" value="@string.Join(",", Model.SelectedLotteries)" />
     <input type="hidden" id="numbersDraftJson" name="numbersDraftJson" value="" />
-    <div class="d-flex justify-content-end gap-2 mb-2">
+    <div class="d-flex justify-content-end gap-2 mb-2 floating-actions">
         <input type="submit" id="createPaperButton" value="Crear" class="btn btn-primary" />
         <input type="button" onclick="location.href='@Url.Action("Clear", "Lottery")'" value="Limpiar" class="btn btn-danger" />
     </div>
@@ -146,7 +156,7 @@
 
 <div class="container-fluid mb-2" id="numbersSection" style="display:@((Model?.Numbers.Any() ?? false) ? "block" : "none");">
         <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8 mb-2 mb-lg-0">
                 <div class="card shadow-sm border-0 h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-2">
@@ -208,6 +218,7 @@
             </div>
         </div>
     </div>
+</div>
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -32,6 +32,10 @@
 </style>
 
 <form asp-action="Save" id="savePaperForm" class="create-compact">
+    @if(TempData["ErrorMessage"] is string errorMessage && !string.IsNullOrWhiteSpace(errorMessage))
+    {
+        <div class="alert alert-danger shadow-sm">@errorMessage</div>
+    }
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="card shadow-sm border-0 mb-3">
         <div class="card-body">
@@ -799,21 +803,40 @@
                 e.preventDefault();
                 var amount = parseFloat($('#Amount').val());
                 var busted = parseFloat($('#Busted').val());
+                const amountValidation = document.querySelector('[data-valmsg-for="Amount"]');
+                const bustedValidation = document.querySelector('[data-valmsg-for="Busted"]');
+                let hasError = false;
 
                 if (numberInput && !numberInput.value) {
                     document.getElementById("bulkNumbersInput")?.scrollIntoView({ behavior: "smooth", block: "center" });
-                    e.preventDefault();
+                    const feedback = document.getElementById("numberFeedback");
+                    if (feedback) feedback.textContent = "Selecciona al menos un número antes de agregar la línea.";
+                    hasError = true;
+                }
+
+                if (Number.isNaN(amount) || amount <= 0) {
+                    if (amountValidation) amountValidation.textContent = "El monto es obligatorio y debe ser mayor a 0.";
+                    $('#Amount').focus();
+                    hasError = true;
+                } else if (amountValidation) {
+                    amountValidation.textContent = '';
+                }
+
+                if (Number.isNaN(busted) || busted < 0) {
+                    if (bustedValidation) bustedValidation.textContent = "El reventado no puede ser negativo.";
+                    hasError = true;
                     return;
                 }
 
                 if (!Number.isNaN(amount) && !Number.isNaN(busted) && busted > amount) {
-                    $('#Busted').siblings('.text-danger').text('El campo no puede ser mayor que el Monto.');
+                    if (bustedValidation) bustedValidation.textContent = 'El reventado no puede ser mayor que el monto.';
                     $('#Busted').focus();
-                    e.preventDefault(); 
+                    hasError = true;
                 }
                 else {
-                    $('#Busted').siblings('.text-danger').text('');
+                    if (bustedValidation) bustedValidation.textContent = '';
                 }
+                if (hasError) return;
                 const hiddenValue = numberInput?.value || "";
                 const parsed = parseNumbersFromText(hiddenValue);
                 if (!parsed.expanded.length) return;
@@ -836,7 +859,40 @@
 
             const savePaperForm = document.getElementById("savePaperForm");
             if (savePaperForm) {
-                savePaperForm.addEventListener("submit", function () {
+                savePaperForm.addEventListener("submit", function (event) {
+                    const selectedLotteryValues = (document.getElementById("selectedLotteriesHidden")?.value || "").split(",").map(x => x.trim()).filter(Boolean);
+                    const drawDateInput = document.getElementById("DrawDate");
+
+                    if (!selectedLotteryValues.length) {
+                        event.preventDefault();
+                        alert("Debe seleccionar al menos un sorteo para crear el papelito.");
+                        return;
+                    }
+
+                    if (!drawDateInput?.value) {
+                        event.preventDefault();
+                        drawDateInput?.focus();
+                        alert("La fecha de sorteo es obligatoria.");
+                        return;
+                    }
+
+                    if (!stagedNumbers.length) {
+                        event.preventDefault();
+                        alert("Debe agregar al menos una línea de números.");
+                        return;
+                    }
+
+                    const invalidLine = stagedNumbers.find(n => {
+                        const amount = Number(n.amount ?? n.Amount ?? 0);
+                        const busted = Number(n.busted ?? n.Busted ?? 0);
+                        return amount <= 0 || busted < 0 || busted > amount;
+                    });
+                    if (invalidLine) {
+                        event.preventDefault();
+                        alert("Revise las líneas: el monto debe ser mayor a 0 y el reventado no puede superar el monto.");
+                        return;
+                    }
+
                     const draftInput = document.getElementById("numbersDraftJson");
                     if (draftInput) draftInput.value = JSON.stringify(stagedNumbers);
                 });

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -29,6 +29,12 @@
     .create-compact .form-group { margin-bottom: .25rem; }
     .create-compact .alert { margin-bottom: .6rem; padding: .55rem .75rem; }
     .create-compact .numbers-summary { min-height: 36px; }
+    .numbers-workspace { background: linear-gradient(180deg,#f8fbff 0%, #ffffff 100%); border: 1px solid #e8eef7; border-radius: 16px; padding: 1rem; }
+    .numbers-header { display:flex; justify-content:space-between; align-items:center; gap:.75rem; flex-wrap:wrap; }
+    .numbers-table-wrap { border: 1px solid #edf1f7; border-radius: 14px; overflow: hidden; background: #fff; }
+    .numbers-table-wrap .table thead th { background: #f4f8ff; border-bottom: 1px solid #e6edf7; font-size: .82rem; text-transform: uppercase; letter-spacing: .03em; }
+    .numbers-table-wrap .table tbody tr:hover { background: #f8fbff; }
+    .numbers-kpi { background: linear-gradient(135deg, #2463eb, #64b5f6); border-radius: 16px; }
 </style>
 
 <form asp-action="Save" id="savePaperForm" class="create-compact">
@@ -129,19 +135,25 @@
     </div>
 </div>
 <div id="addSection" class="mt-2" style="display:@(hasSelectedLotteries ? "block" : "none");">
-    <partial name="_Add" model="new Numbers()"/>
+    <div class="numbers-workspace shadow-sm">
+        <div class="numbers-header mb-2">
+            <h5 class="fw-bold mb-0">Carga de números</h5>
+            <span class="badge bg-primary-subtle text-primary-emphasis border">Paso 1: arma tus líneas</span>
+        </div>
+        <partial name="_Add" model="new Numbers()"/>
+    </div>
 </div>
 
 <div class="container-fluid mb-2" id="numbersSection" style="display:@((Model?.Numbers.Any() ?? false) ? "block" : "none");">
         <div class="row">
             <div class="col-lg-8">
-                <div class="card shadow-sm border-0">
+                <div class="card shadow-sm border-0 h-100">
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-2">
                             <h5 class="mb-0 fw-bold">Números cargados</h5>
                             <span class="badge bg-secondary text-white border" id="totalLinesBadge">Total líneas: @Model.Numbers.Count()</span>
                         </div>
-                        <div class="table-responsive container overflow-auto">
+                        <div class="table-responsive numbers-table-wrap overflow-auto">
                             <table class="table table-hover align-middle mb-0">
                                 <thead class="table-light">
                             <tr>
@@ -182,7 +194,7 @@
 
             </div>
             <div class="col-lg-4">
-                <div class="card text-white border-0 shadow-sm" style="background: linear-gradient(135deg, #3B82F6, #64b5f6);">
+                <div class="card text-white border-0 shadow-sm numbers-kpi">
                     <div class="card-body">
                         <h2 class="card-title">Resumen</h2>
                         <p class="card-text mb-1">Monto Total: <span id="summaryAmountTotal">@Model.Numbers.Sum(x => x.Amount).ToCRC()</span></p>

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -5,9 +5,13 @@
     var busted = ViewData["busted"] as bool?;
 }
 
-<hr />
+<hr class="my-2" />
 
 <style>
+    #addNumberForm { background: #fff; border: 1px solid #e8eef7; border-radius: 14px; padding: .9rem; }
+    #addNumberForm label { font-weight: 600; color: #1f2a44; }
+    #bulkNumbersInput { border-radius: 10px; border-color: #dce6f6; }
+    #bulkNumbersInput:focus, #addNumberForm .form-control:focus { box-shadow: 0 0 0 .2rem rgba(59,130,246,.15); border-color: #8fb0f5; }
     .number-grid { display:grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap:.25rem; }
     .number-grid .number-cell { position: relative; width:100%; min-width:0 !important; padding: .35rem .1rem; font-size: .72rem; line-height: 1.1; border-radius: 12px; }
     .numbers-summary { min-height: 44px; }
@@ -19,7 +23,7 @@
 
 <form asp-action="Add" id="addNumberForm">
     <input type="hidden" id="addSelectedLotteries" name="selectedLotteries" value="" />
-    <div class="row g-3">
+    <div class="row g-3 align-items-end">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
         <div class="form-group col-md-2">
             <label asp-for="Amount" class="control-label">Monto</label>
@@ -38,8 +42,9 @@
                 <label class="form-label mb-1">Pegar lista de números</label>
                 <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: 00+01+78'></textarea>
                 <small class="text-muted d-block mt-2">Solo pegado / digitación. Se formatea automáticamente como 00+01+78.</small>
-                <div class="mt-2">
+                <div class="mt-2 d-flex gap-2 flex-wrap">
                     <button type="button" class="btn btn-sm btn-primary" onclick="addNumbersFromTextarea()">Agregar al cuadro final</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar texto</button>
                 </div>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>
@@ -48,4 +53,4 @@
     </div>
 </form>
 
-<hr />
+<hr class="my-2" />

--- a/Views/Lottery/_Add.cshtml
+++ b/Views/Lottery/_Add.cshtml
@@ -36,15 +36,15 @@
             <span asp-validation-for="Busted" class="text-danger"></span>
         </div>
         <div class="form-group col-md-8">
-            <label asp-for="Value" class="control-label">Números</label>
+            <label asp-for="Value" class="control-label d-flex justify-content-between align-items-center mb-1">
+                <span>Números</span>
+                <span class="text-muted fw-normal small">Pegar lista de números</span>
+            </label>
             <input asp-for="Value" id="number" type="hidden" />
             <div class="mb-2">
-                <label class="form-label mb-1">Pegar lista de números</label>
-                <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: 00+01+78'></textarea>
-                <small class="text-muted d-block mt-2">Solo pegado / digitación. Se formatea automáticamente como 00+01+78.</small>
-                <div class="mt-2 d-flex gap-2 flex-wrap">
-                    <button type="button" class="btn btn-sm btn-primary" onclick="addNumbersFromTextarea()">Agregar al cuadro final</button>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearBulkNumbersInput()">Limpiar texto</button>
+                <div class="d-flex gap-2 align-items-start">
+                    <textarea id="bulkNumbersInput" class="form-control form-control-sm" rows="3" placeholder='Ej: 00+01+78'></textarea>
+                    <button type="button" class="btn btn-sm btn-primary text-nowrap" onclick="addNumbersFromTextarea()">Agregar</button>
                 </div>
             </div>
             <small id="numberFeedback" class="form-text text-danger"></small>


### PR DESCRIPTION
### Motivation
- Evitar la creación de papelitos incompletos o inválidos desde la interfaz de `Lottery/Create` y asegurar integridad en el servidor.
- Impedir que se agreguen líneas sin monto válido o con `Reventado` mayor que el `Monto` y mejorar la experiencia mostrando mensajes claros.

### Description
- Agregadas validaciones servidor-side en `LotteryController.Save` para verificar que exista al menos un sorteo seleccionado (`selectedLotteries`), que `drawDate` esté presente, que haya al menos una línea de números con monto > 0 o reventado > 0, y que ninguna línea tenga `Busted > Amount`; en errores se setea `TempData["ErrorMessage"]` y se redirige a `Create` preservando el estado del papelito.
- Filtrado de `paper.Numbers` para persistir solo las líneas válidas antes de crear los registros por sorteo mediante `paper.Numbers = validNumbers`.
- Añadido aviso en la vista `Views/Lottery/Create.cshtml` que renderiza `TempData["ErrorMessage"]` como una alerta visible cuando el servidor reporta errores.
- Refuerzos client-side en `Views/Lottery/Create.cshtml`: la lógica de `#addNumberForm` ahora exige selección de números, `Amount > 0`, `Busted >= 0` y `Busted <= Amount`, y el handler de submit del formulario principal valida que exista al menos un sorteo, fecha y líneas válidas antes de enviar (llenando `numbersDraftJson`).
- El flujo de impresión ya concatena múltiples sorteos en `Print` usando `paper.Lottery = string.Join(...)`, por lo que los papeles creados por sorteo múltiple se mostrarán en el tiquete final.

### Testing
- Intenté ejecutar `dotnet build` en este entorno, pero falló debido a que `dotnet` no está disponible (`/bin/bash: line 1: dotnet: command not found`).
- No se ejecutaron pruebas automatizadas adicionales en este entorno por la falta del SDK; los cambios están limitados a lógica de validación y la vista y deben ser verificados con `dotnet build` y pruebas funcionales en un entorno con .NET instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164ad5a7ac8330a9dc61161eda1335)