### PR TITLE
Mejorar UI de Lottery/Create para mayor legibilidad

### DIFF
--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -39,7 +39,15 @@
     .numbers-table-wrap .table tbody tr:hover { background: #f8fbff; }
     .numbers-kpi { background: linear-gradient(135deg, #2463eb, #64b5f6); border-radius: 16px; }
     .config-card { border-radius: 16px; border: 1px solid #ebeff5; }
-    .floating-actions { position: sticky; bottom: .6rem; z-index: 5; background: rgba(255,255,255,.9); backdrop-filter: blur(3px); border: 1px solid #e8eef7; border-radius: 12px; padding: .5rem; }
+    .floating-actions { position: sticky; bottom: .6rem; z-index: 5; background: rgba(255,255,255,.96); backdrop-filter: blur(3px); border: 1px solid #e8eef7; border-radius: 12px; padding: .6rem; box-shadow: 0 8px 24px rgba(31,54,88,.08); }
+    .custom-multi-select { cursor: pointer; min-height: 44px; display:flex; align-items:center; border-radius: 10px; border-color:#d9e2f0; }
+    .custom-dropdown-list { border-radius: 0 0 10px 10px; border-color:#d9e2f0; }
+    .custom-dropdown-list .list-group-item { border-color:#edf2fa; }
+    .custom-dropdown-list .list-group-item:hover { background:#f7faff; }
+    #selectedLotteriesSummary .alert { border:1px solid #d9ebff; background:#f3f9ff; }
+    #selectedLotteriesBadges .badge { font-weight:600; padding:.5rem .65rem; }
+    #numbersSection .card, #addSection .numbers-workspace { border-radius: 16px; }
+    #numbersSection .card-body { padding: 1rem 1.1rem; }
     @@media (max-width: 767px) {
         .floating-actions { position: static; }
     }
@@ -67,14 +75,14 @@
                 <div class="form-group col-md-4">
                     <label asp-for="SelectedLotteries" class="control-label fw-semibold">Sorteos</label>
                     <div class="position-relative">
-                        <div id="customSelect" class="form-select" onclick="toggleDropdown()">
+                        <div id="customSelect" class="form-select custom-multi-select" onclick="toggleDropdown()">
                             <span id="selectedLotteriesText">Seleccione uno o varios</span>
                         </div>
 
 
                         <!-- UL con checkboxes (se muestra al hacer clic) -->
                         <ul id="customDropdown"
-                            class="list-group position-absolute w-100 shadow-sm"
+                            class="list-group position-absolute w-100 shadow-sm custom-dropdown-list"
                             style="z-index: 1000; display: none; max-height: 320px; overflow-y: auto; background: white; border: 1px solid #ced4da; border-top: none;">
                             @if(ViewData["Names"] is IList<Lottery> lotteries)
                             {
@@ -122,7 +130,7 @@
     </div>
     <input type="hidden" id="selectedLotteriesHidden" name="selectedLotteries" value="@string.Join(",", Model.SelectedLotteries)" />
     <input type="hidden" id="numbersDraftJson" name="numbersDraftJson" value="" />
-    <div class="d-flex justify-content-end gap-2 mb-2 floating-actions">
+    <div class="d-flex justify-content-end gap-2 mb-3 floating-actions">
         <input type="submit" id="createPaperButton" value="Crear" class="btn btn-primary" />
         <input type="button" onclick="location.href='@Url.Action("Clear", "Lottery")'" value="Limpiar" class="btn btn-danger" />
     </div>
@@ -148,6 +156,7 @@
     <div class="numbers-workspace shadow-sm">
         <div class="numbers-header mb-2">
             <h5 class="fw-bold mb-0">Carga de números</h5>
+            <small class="text-muted">Agrega una o varias líneas y revisa el resumen antes de crear.</small>
             <span class="badge bg-primary-subtle text-primary-emphasis border">Paso 1: arma tus líneas</span>
         </div>
         <partial name="_Add" model="new Numbers()"/>
@@ -168,7 +177,7 @@
                                 <thead class="table-light">
                             <tr>
                                 <th></th>
-                                <th>Numero</th>
+                                <th>Número</th>
                                 <th>Monto</th>
                                 <th>Reventado</th>
                                 <th></th>


### PR DESCRIPTION
### Motivation
- La pantalla de creación de papelitos (`Lottery/Create`) tenía una apariencia poco cuidada y necesitaba mejor jerarquía visual, espaciado y consistencia en bordes para facilitar la carga rápida de líneas y selección de sorteos.

### Description
- Actualiza estilos y layout en `Views/Lottery/Create.cshtml` para pulir la barra de acciones sticky, añadir sombra y ajustar padding para mejor visualización de las acciones principales.
- Mejora el selector múltiple de sorteos aplicando clases de presentación (`.custom-multi-select`, `.custom-dropdown-list`) para aumentar la altura clickeable, bordes redondeados y estados hover en ítems.
- Refina el bloque de “Sorteos seleccionados” con alert y badges más legibles, añade microcopy orientativa en la sección de carga de números y corrige la etiqueta de columna a `Número`.

### Testing
- Se intentó ejecutar `dotnet build` en el entorno de CI local, pero falló por falta del SDK (`dotnet: command not found`), por lo que no se realizaron builds automatizados aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1654da7514833081d2101ae24de695)