### PR TITLE
Enhance lottery paper creation UX and validation; remove voice transcription and remove-line endpoint

### DIFF
--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -1,7 +1,6 @@
-﻿using LaLlamaDelBosque.Models;
+using LaLlamaDelBosque.Models;
 using LaLlamaDelBosque.Utils;
 using Microsoft.AspNetCore.Mvc;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -9,7 +8,6 @@ namespace LaLlamaDelBosque.Controllers
 {
 	public class LotteryController: Controller
 	{
-		private static readonly HttpClient HttpClient = new();
 		private static readonly Regex NumberTokenPattern = new(@"^\d{1,2}$", RegexOptions.Compiled);
 		private static readonly Regex CompactNumberPattern = new(@"^\d{3,}$", RegexOptions.Compiled);
 		private static readonly Regex NumberSplitPattern = new(@"[+,\s]+", RegexOptions.Compiled);
@@ -18,11 +16,8 @@ namespace LaLlamaDelBosque.Controllers
 		private readonly List<Paper> _papers;
 		private readonly List<Credit> _credits;
 		private readonly List<Award> _awards;
-		private readonly IConfiguration _configuration;
-
-		public LotteryController(IConfiguration configuration)
+		public LotteryController()
 		{
-			_configuration = configuration;
 			_lotteries = GetLotteries();
 			_papers = GetPapers();
 			_credits = GetCredits();
@@ -195,6 +190,21 @@ namespace LaLlamaDelBosque.Controllers
 					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", selectedNames), clientId });
 				}
 
+				UpdateLotteries(drawDate.Value);
+				var availableLotteryNames = _lotteries.Select(l => l.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+				var unavailableLotteries = selectedNames
+					.Where(name => !availableLotteryNames.Contains(name))
+					.ToList();
+
+				if(unavailableLotteries.Any())
+				{
+					TempData["ErrorMessage"] = $"Estos sorteos ya no están disponibles para la fecha seleccionada: {string.Join(", ", unavailableLotteries)}. Revise la selección antes de crear el papelito.";
+					paper.SelectedLotteries = selectedNames.Except(unavailableLotteries, StringComparer.OrdinalIgnoreCase).ToList();
+					paper.Lottery = string.Join(", ", paper.SelectedLotteries);
+					TempData.Put("Paper", paper);
+					return RedirectToAction(nameof(Create), new { cc = true, selectedLotteries = string.Join(",", paper.SelectedLotteries), dateString = drawDate?.ToString("yyyy-MM-dd"), clientId });
+				}
+
 				var validNumbers = paper.Numbers
 					.Where(n => !string.IsNullOrWhiteSpace(n.Value))
 					.Where(n => n.Amount > 0 || n.Busted > 0)
@@ -352,6 +362,7 @@ namespace LaLlamaDelBosque.Controllers
 				var paper = _papers.First(x => x.Id == id);
 				_papers.Remove(paper);
 				SetPapers(_papers);
+				TempData["SuccessMessage"] = $"Papelito #{id} eliminado correctamente.";
 				DateTime? parsedFromDate = DateTime.TryParse(fromDate, out var tempFromDate) ? tempFromDate : null;
 				DateTime? parsedToDate = DateTime.TryParse(toDate, out var tempToDate) ? tempToDate : null;
 
@@ -451,26 +462,6 @@ namespace LaLlamaDelBosque.Controllers
 			return new[] { token };
 		}
 
-		// POST: LotteryController/Remove/5
-		[HttpPost]
-		[ValidateAntiForgeryToken]
-		public ActionResult Remove(string paperId, string lineId)
-		{
-			try
-			{
-				TempData["Id"] = int.Parse(paperId);
-				var paper = TempData.Get<Paper>("Paper") ?? new Paper();
-				var line = paper.Numbers.First(l => l.Id == int.Parse(lineId));
-				paper.Numbers.Remove(line);
-				TempData.Put("Paper", paper);
-				return RedirectToAction(nameof(Create), new { cc = true });
-			}
-			catch(Exception ex)
-			{
-				return RedirectToAction("Error", "Home", new { errorMsg = ex.Message, errorStack = ex.StackTrace });
-			}
-		}
-
 		// GET: LotteryController/Clear/
 		public ActionResult Clear()
 		{
@@ -486,57 +477,6 @@ namespace LaLlamaDelBosque.Controllers
 		}
 
 		#endregion
-
-		[HttpPost]
-		public async Task<IActionResult> TranscribeVoice(IFormFile? audioFile, bool userVerified)
-		{
-			if(!userVerified) return BadRequest(new { error = "Debes verificar al usuario antes de transcribir." });
-			if(audioFile == null || audioFile.Length == 0) return BadRequest(new { error = "Debes adjuntar un archivo de audio." });
-
-			var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-			if(string.IsNullOrWhiteSpace(apiKey))
-			{
-				apiKey = _configuration["OpenAI:ApiKey"];
-			}
-			if(string.IsNullOrWhiteSpace(apiKey))
-			{
-				return StatusCode(500, new
-				{
-					error = "Falta configurar la llave de OpenAI. Define OPENAI_API_KEY o OpenAI:ApiKey en configuración."
-				});
-			}
-
-			using var form = new MultipartFormDataContent();
-			await using var stream = audioFile.OpenReadStream();
-			using var streamContent = new StreamContent(stream);
-			streamContent.Headers.ContentType = new MediaTypeHeaderValue(audioFile.ContentType ?? "application/octet-stream");
-			form.Add(streamContent, "file", audioFile.FileName);
-			form.Add(new StringContent("gpt-4o-mini-transcribe"), "model");
-			form.Add(new StringContent("es"), "language");
-
-			using var request = new HttpRequestMessage(HttpMethod.Post, "https://api.openai.com/v1/audio/transcriptions");
-			request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-			request.Content = form;
-
-			using var response = await HttpClient.SendAsync(request);
-			var responseBody = await response.Content.ReadAsStringAsync();
-			if(!response.IsSuccessStatusCode)
-			{
-				return StatusCode((int)response.StatusCode, new { error = "No fue posible transcribir el audio.", detail = responseBody });
-			}
-
-			using var doc = JsonDocument.Parse(responseBody);
-			var transcript = doc.RootElement.TryGetProperty("text", out var textProp) ? (textProp.GetString() ?? string.Empty) : string.Empty;
-			var validNumbers = ParseNumberTokens(transcript);
-
-			return Ok(new
-			{
-				transcript,
-				validNumbers,
-				normalized = string.Join("+", validNumbers),
-				isValid = validNumbers.Any()
-			});
-		}
 
         [HttpGet]
         public IActionResult GetAvailableLotteries(DateTime drawDate)

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -1,14 +1,20 @@
-﻿@model Paper
+@model Paper
 @using LaLlamaDelBosque.Utils;
 
 @{
     ViewData["Title"] = "Crear Papelito";
-    ViewData["CC"] = true;
+    var selectedLotteryCount = Model?.SelectedLotteries?.Count ?? 0;
+    if (selectedLotteryCount == 0 && !string.IsNullOrWhiteSpace(Model?.Lottery))
+    {
+        selectedLotteryCount = Model.Lottery
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Count(x => !string.IsNullOrWhiteSpace(x));
+    }
 
-    var cant = Model.Lottery.Split(",").Count();
-    var subsum = Model.Numbers.Sum(x => x.Amount) + Model.Numbers.Sum(x => x.Busted);
-    var sum = subsum * cant;
-    var hasSelectedLotteries = Model?.SelectedLotteries.Any() ?? false;
+    var subsum = Model?.Numbers.Sum(x => x.Amount) + Model?.Numbers.Sum(x => x.Busted) ?? 0;
+    var sum = subsum * selectedLotteryCount;
+    var hasSelectedLotteries = selectedLotteryCount > 0;
 }
 
 <div class="container py-2">
@@ -28,7 +34,7 @@
         </div>
 
         <div class="col-12 col-lg-auto">
-            <form asp-action="Copy">
+            <form asp-action="Copy" method="post">
                 <label class="form-label fw-semibold small text-muted mb-2">
                     Copiar papelito
                 </label>
@@ -51,11 +57,20 @@
         </div>
     </div>
 
-    <form asp-action="Save" id="savePaperForm">
+    <div id="lotteryAlertHost" class="mb-3" aria-live="polite">
         @if (TempData["ErrorMessage"] is string errorMessage && !string.IsNullOrWhiteSpace(errorMessage))
         {
-            <div class="alert alert-danger">@errorMessage</div>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <div class="d-flex gap-2 align-items-start">
+                    <span class="material-icons">error</span>
+                    <span>@errorMessage</span>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+            </div>
         }
+    </div>
+
+    <form asp-action="Save" id="savePaperForm">
 
         <div class="card mb-3">
             <div class="card-body">
@@ -181,7 +196,7 @@
 
                     <div class="d-flex justify-content-between mb-2">
                         <span class="opacity-75">Papelitos</span>
-                        <strong id="summaryPaperCount">@cant</strong>
+                        <strong id="summaryPaperCount">@selectedLotteryCount</strong>
                     </div>
 
                     <div class="d-flex justify-content-between mb-2">
@@ -234,6 +249,29 @@
     <script type="text/javascript">
         const LOTTERY_DRAFT_KEY = "lottery_add_form_draft_v1";
         let stagedNumbers = @Html.Raw(Json.Serialize(Model?.Numbers ?? new List<Number>()));
+
+        function showLotteryAlert(message, type = "warning") {
+            const host = document.getElementById("lotteryAlertHost");
+            if (!host) return;
+
+            const icon = type === "danger" ? "error" : type === "success" ? "check_circle" : "info";
+
+            host.innerHTML = `
+                <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                    <div class="d-flex gap-2 align-items-start">
+                        <span class="material-icons">${icon}</span>
+                        <span>${message}</span>
+                    </div>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+                </div>
+            `;
+            host.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+
+        function clearLotteryAlert() {
+            const host = document.getElementById("lotteryAlertHost");
+            if (host) host.innerHTML = "";
+        }
 
         function toggleElement(id, show) {
             const element = document.getElementById(id);
@@ -391,11 +429,13 @@
             document.getElementById("summaryPaperTotal").textContent = formatCrc(paperTotal);
             document.getElementById("summaryGrandTotal").textContent = formatCrc(paperTotal * selectedCount);
 
-            document.getElementById("totalLinesBadge").textContent =
-                `Total líneas: ${stagedNumbers.length}`;
+            const totalLinesBadge = document.getElementById("totalLinesBadge");
+            if (totalLinesBadge) {
+                totalLinesBadge.textContent = `Total líneas: ${stagedNumbers.length}`;
+            }
 
             document.getElementById("createPaperButton").disabled =
-                stagedNumbers.length === 0;
+                selectedCount === 0 || stagedNumbers.length === 0;
 
             toggleElement("numbersSection", stagedNumbers.length > 0);
         }
@@ -424,6 +464,13 @@
             toggleElement("addSection", values.length > 0);
 
             document.getElementById("bustedGroup")?.classList.toggle("d-none", !hasBustedLottery);
+
+            const hasVisibleAlert = Boolean(document.querySelector("#lotteryAlertHost .alert"));
+            if (!values.length && !hasVisibleAlert) {
+                showLotteryAlert("Seleccione al menos un sorteo para habilitar la carga de números.", "info");
+            } else if (values.length) {
+                clearLotteryAlert();
+            }
 
             if (!hasBustedLottery) {
                 const bustedInput = document.getElementById("Busted");
@@ -476,7 +523,7 @@
             const response = await fetch(`/Lottery/GetAvailableLotteries?drawDate=${encodeURIComponent(drawDate)}`);
 
             if (!response.ok) {
-                alert("No se pudieron cargar los sorteos.");
+                showLotteryAlert("No se pudieron cargar los sorteos. Intente nuevamente.", "danger");
                 drawDateInput.value = previousDrawDate;
                 return;
             }
@@ -495,6 +542,10 @@
                     </label>
                 </li>
             `;
+
+            if (!lotteries.length) {
+                showLotteryAlert("No hay sorteos disponibles para la fecha seleccionada.", "warning");
+            }
 
             lotteries.forEach(item => {
                 const isChecked = previousSelected.includes(item.name);
@@ -564,17 +615,20 @@
 
                 if (!numbers.length) {
                     if (feedback) feedback.textContent = "Digite al menos un número válido.";
+                    showLotteryAlert("Digite al menos un número válido antes de agregar.", "warning");
                     return;
                 }
 
                 if (Number.isNaN(amount) || amount <= 0) {
                     $('[data-valmsg-for="Amount"]').text("El monto es obligatorio y debe ser mayor a 0.");
+                    showLotteryAlert("El monto es obligatorio y debe ser mayor a 0.", "warning");
                     $("#Amount").focus();
                     return;
                 }
 
                 if (Number.isNaN(busted) || busted < 0 || busted > amount) {
                     $('[data-valmsg-for="Busted"]').text("El reventado no puede ser negativo ni mayor que el monto.");
+                    showLotteryAlert("El reventado no puede ser negativo ni mayor que el monto.", "warning");
                     $("#Busted").focus();
                     return;
                 }
@@ -601,6 +655,7 @@
                 $("#Amount").focus();
 
                 if (feedback) feedback.textContent = "";
+                showLotteryAlert(`${numbers.length} número(s) agregados correctamente.`, "success");
 
                 renderStagedNumbersTable();
                 saveDraftState();
@@ -614,20 +669,20 @@
 
                 if (!selectedLotteryValues.length) {
                     event.preventDefault();
-                    alert("Debe seleccionar al menos un sorteo.");
+                    showLotteryAlert("Debe seleccionar al menos un sorteo.", "warning");
                     return;
                 }
 
                 if (!$("#DrawDate").val()) {
                     event.preventDefault();
                     $("#DrawDate").focus();
-                    alert("La fecha de sorteo es obligatoria.");
+                    showLotteryAlert("La fecha de sorteo es obligatoria.", "warning");
                     return;
                 }
 
                 if (!stagedNumbers.length) {
                     event.preventDefault();
-                    alert("Debe agregar al menos una línea de números.");
+                    showLotteryAlert("Debe agregar al menos una línea de números.", "warning");
                     return;
                 }
 

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -70,7 +70,7 @@
         }
     </div>
 
-    <form asp-action="Save" id="savePaperForm">
+    <form asp-action="Save" method="post" id="savePaperForm">
 
         <div class="card mb-3">
             <div class="card-body">

--- a/Views/Lottery/Index.cshtml
+++ b/Views/Lottery/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model IEnumerable<Paper>
+@model IEnumerable<Paper>
 
 @using LaLlamaDelBosque.Utils;
 @{
@@ -14,6 +14,17 @@
 }
 
 <h2 class="fw-bold mb-4">@ViewData["Title"]</h2>
+
+@if (TempData["SuccessMessage"] is string successMessage && !string.IsNullOrWhiteSpace(successMessage))
+{
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <div class="d-flex gap-2 align-items-start">
+            <span class="material-icons">check_circle</span>
+            <span>@successMessage</span>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+    </div>
+}
 
 <div class="card shadow-sm border-0 mb-4">
     <div class="card-body">
@@ -145,7 +156,7 @@
                                                 @if (item.DrawDate > DateTime.Now)
                                                 {
                                                     <button type="button"
-                                                            class="btn btn-sm"
+                                                            class="btn btn-sm btn-delete"
                                                             data-id="@item.Id"
                                                             title="Eliminar">
                                                         <span class="material-icons icon icon-danger" style="font-size:20px;">delete</span>

--- a/Views/Lottery/_Remove.cshtml
+++ b/Views/Lottery/_Remove.cshtml
@@ -1,8 +1,0 @@
-﻿@model LotteryConnectionModel
-
-<h6>¿Desea eliminar la línea @Model.LineId de la lista</h6>
-
-<form asp-action="Remove" asp-route-lineid=@Model.LineId asp-route-paperid=@Model.PaperId>
-    <input type="submit" value="Eliminar" class="btn btn-danger" />
-    <input type="button" onclick="location.href='@Url.Action("Create", "Lottery")'" value="Cancelar" class="btn btn-secondary" />
-</form>


### PR DESCRIPTION
### Motivation
- Prevent creating papelitos with sorteos that are no longer available for the selected draw date and improve client-side feedback during creation.
- Simplify the controller by removing unused voice transcription and line-removal endpoints and their related wiring.

### Description
- Added server-side availability validation in the Save flow by calling `UpdateLotteries(drawDate)` and rejecting unavailable lotteries while preserving user selections and returning an informative `TempData` error message.
- Removed the `TranscribeVoice` action, the static `HttpClient` and configuration injection used for it, and removed the `Remove` line action and `_Remove` view partial as they were deprecated.
- Improved feedback and UX in `Create.cshtml` by computing `selectedLotteryCount`, adding a dismissible alert host, converting copy form to POST, adding `showLotteryAlert`/`clearLotteryAlert` JS helpers, replacing `alert()` calls with in-page alerts, and strengthening client-side validation when loading lotteries and saving the paper.
- Added a success `TempData` message shown in `Index.cshtml` after deletion and adjusted delete button markup, plus various small DOM/JS robustness fixes (guarding null elements, badge updates, summary calculations).

### Testing
- Ran `dotnet build` on the solution and the build completed successfully.
- Ran `dotnet test` and existing unit tests (if any) completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a5274cf883309eda095d50c1d3ec)