### PR TITLE
Update Nica schedules and refresh feedback

### DIFF
--- a/Controllers/AwardController.cs
+++ b/Controllers/AwardController.cs
@@ -59,11 +59,13 @@ namespace LaLlamaDelBosque.Controllers
                     award.AwardLines.AddRange(awardLines);
                 }
                 SetAwards(_awards);
+                TempData["SuccessMessage"] = $"Actualización completada. Se registraron {award.AwardLines.Count} resultados encontrados en las fuentes.";
                 return RedirectToAction(nameof(Index));
 			}
 			catch(Exception ex)
 			{
-				return RedirectToAction("Error", "Home", new { errorMsg = ex.Message, errorStack = ex.StackTrace });
+				TempData["ErrorMessage"] = $"No se pudo completar la actualización automática: {ex.Message}. Revise las fuentes oficiales y vuelva a intentarlo.";
+				return RedirectToAction(nameof(Index));
 			}
 		}
 

--- a/Controllers/CreditController.cs
+++ b/Controllers/CreditController.cs
@@ -55,6 +55,7 @@ namespace LaLlamaDelBosque.Controllers
             ViewBag.LimitExceededClientTotal = TempData["LimitExceededClientTotal"] as string;
             ViewBag.LimitExceededClientLimit = TempData["LimitExceededClientLimit"] as string;
             ViewBag.ShowFortnightReminder = IsFortnightCollectionWindow(DateTime.Today);
+            ViewBag.FortnightReminderKey = GetFortnightCollectionReminderKey(DateTime.Today);
 
             ViewBag.TotalPages = totalPages;
             ViewBag.CurrentPage = currentPage;
@@ -306,17 +307,21 @@ namespace LaLlamaDelBosque.Controllers
 
         private static bool IsFortnightCollectionWindow(DateTime date)
         {
+            return GetFortnightCollectionReminderKey(date) is not null;
+        }
+
+        private static string? GetFortnightCollectionReminderKey(DateTime date)
+        {
             var day = date.Day;
             var daysInMonth = DateTime.DaysInMonth(date.Year, date.Month);
 
-            var firstWindowStart = 14;
-            var firstWindowEnd = 16;
+            if(day >= 14 && day <= 16)
+                return $"fortnight-collection-{date:yyyy-MM}-midmonth";
 
-            var secondWindowStart = Math.Max(daysInMonth - 2, 1);
-            var secondWindowEnd = daysInMonth;
+            if(day >= Math.Max(daysInMonth - 2, 1) && day <= daysInMonth)
+                return $"fortnight-collection-{date:yyyy-MM}-endmonth";
 
-            return (day >= firstWindowStart && day <= firstWindowEnd)
-                || (day >= secondWindowStart && day <= secondWindowEnd);
+            return null;
         }
 
         private CreditModel GetCredits()

--- a/Controllers/NoteController.cs
+++ b/Controllers/NoteController.cs
@@ -3,103 +3,102 @@ using LaLlamaDelBosque.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace KrakenNotes.Web.Controllers
+namespace LaLlamaDelBosque.Controllers
 {
     [Authorize]
     public class NoteController: Controller
     {
-        private NoteModel _notes;
+        private readonly NoteModel _notes;
 
         public NoteController()
         {
             _notes = GetNotes();
         }
 
-        public IActionResult Index()
+        public IActionResult Index(string? searchText)
         {
-            return View(_notes.Notes);
+            var notes = _notes.Notes.AsEnumerable();
+
+            if(!string.IsNullOrWhiteSpace(searchText))
+                notes = notes.Where(n => n.Title.Contains(searchText, StringComparison.OrdinalIgnoreCase));
+
+            ViewBag.SearchText = searchText;
+            return View(notes.OrderBy(n => n.Title).ToList());
         }
 
         [HttpGet]
         public IActionResult Create()
         {
-            return View();
+            return View(new Note());
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public IActionResult Create(Note model)
         {
-            model.Id = _notes.Notes.LastOrDefault()?.Id + 1 ?? 1;
+            if(!ModelState.IsValid)
+                return View(model);
+
+            model.Id = _notes.Notes.Any() ? _notes.Notes.Max(n => n.Id) + 1 : 1;
             _notes.Notes.Add(model);
             SetNotes(_notes);
-            return RedirectToAction("Index");
+            TempData["SuccessMessage"] = "Nota creada correctamente.";
+            return RedirectToAction(nameof(Index));
         }
 
         [HttpGet]
         public IActionResult Edit(int id)
         {
             var note = _notes.Notes.FirstOrDefault(n => n.Id == id);
+            if(note is null)
+                return NotFound();
+
             return View(note);
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public ActionResult Edit(Note model)
         {
-            var note = _notes.Notes.FirstOrDefault(n => n.Id == model.Id);
-            if(note != null)
-            {
-                note.Title = model.Title;
-                note.Value = model.Value;
-                SetNotes(_notes);
-            }
-            return RedirectToAction("Index");
-        }
+            if(!ModelState.IsValid)
+                return View(model);
 
-        // GET: CreditController/Delete/5
-        public ActionResult Delete(int id)
-        {
-            TempData["Id"] = id;
-            TempData["Method"] = "Delete";
+            var note = _notes.Notes.FirstOrDefault(n => n.Id == model.Id);
+            if(note is null)
+                return NotFound();
+
+            note.Title = model.Title;
+            note.Value = model.Value;
+            SetNotes(_notes);
+            TempData["SuccessMessage"] = "Nota actualizada correctamente.";
             return RedirectToAction(nameof(Index));
         }
 
-        // POST: CreditController/Delete/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public IActionResult Delete(string id)
+        public IActionResult Delete(int id)
         {
-            _notes.Notes.RemoveAll(n => n.Id == int.Parse(id));
+            var removed = _notes.Notes.RemoveAll(n => n.Id == id) > 0;
+            if(!removed)
+                return NotFound();
+
             SetNotes(_notes);
-            return RedirectToAction("Index");
+            TempData["SuccessMessage"] = "Nota eliminada correctamente.";
+            return RedirectToAction(nameof(Index));
         }
 
         public IActionResult Search(SearchModel srcModel)
         {
-            var result = _notes.Notes.FindAll(n => n.Title.Contains(srcModel.SearchText));
-
-            var sResult = result.Select(n => new Note
-            {
-                Value = n.Value,
-                Id = n.Id,
-                Title = n.Title
-            });
-
-            var model = new SearchModel
-            {
-                SearchText = "",
-                SearchResult = sResult
-            };
-
-            return View(model);
+            return RedirectToAction(nameof(Index), new { searchText = srcModel.SearchText });
         }
 
-        private NoteModel GetNotes()
+        private static NoteModel GetNotes()
         {
             var notes = JsonFile.Read<NoteModel>("Notes", new NoteModel());
             return notes;
         }
 
-        private void SetNotes(NoteModel notes)
+        private static void SetNotes(NoteModel notes)
         {
             JsonFile.Write<NoteModel>("Notes", notes);
         }

--- a/Data/Lotteries.json
+++ b/Data/Lotteries.json
@@ -32,8 +32,8 @@
     },
     {
       "Order": 2,
-      "Name": "NICA 12 PM",
-      "Hour": "12:00:00",
+      "Name": "NICA 11 AM",
+      "Hour": "11:00:00",
       "Busted": true
     },
     {
@@ -46,7 +46,11 @@
       "Order": 9,
       "Name": "NICA 6 PM",
       "Hour": "18:00:00",
-      "Busted": true
+      "Busted": true,
+      "Days": [
+        "Saturday",
+        "Sunday"
+      ]
     },
     {
       "Order": 11,

--- a/Data/ScrapingLotteries.json
+++ b/Data/ScrapingLotteries.json
@@ -9,8 +9,8 @@
     {
       "Type": "NICA",
       "Order": 2,
-      "Name": "Lotería Nica 12PM",
-      "Hour": "12:00 PM"
+      "Name": "Lotería Nica 11AM",
+      "Hour": "11:00 AM"
     },
     {
       "Order": 3,

--- a/Models/NoteModel.cs
+++ b/Models/NoteModel.cs
@@ -16,7 +16,7 @@ namespace LaLlamaDelBosque.Models
         public string Title { get; set; } = "";
 
         [Required(ErrorMessage = "El campo es requerido")]
-        [Range(10, 1000000, ErrorMessage = "La longitud de la descripción debe estar entre {2} y {1}.")]
+        [Range(10, 1000000, ErrorMessage = "El valor debe estar entre {1} y {2}.")]
         public double Value { get; set; }
     }
 }

--- a/Services/Scrapers/NicaraguaLotoDiariaScraper.cs
+++ b/Services/Scrapers/NicaraguaLotoDiariaScraper.cs
@@ -24,7 +24,7 @@ namespace LaLlamaDelBosque.Services.Scrapers
 		{
 			var awardLines = new List<AwardLine>();
 
-			// NICA: mapa literal "12PM", "3PM", "6PM", "9PM"
+			// NICA: mapa literal "11AM", "3PM", "6PM", "9PM"
 			var hourToLottery = scrapingLotteries
 				.Where(x => x.Type == "NICA" && !string.IsNullOrWhiteSpace(x.Hour))
 				.ToDictionary(x => x.Hour!.Trim().ToUpperInvariant(), x => x);
@@ -57,6 +57,9 @@ namespace LaLlamaDelBosque.Services.Scrapers
 				var hourKey = $"{int.Parse(m.Groups[1].Value)}:00 {m.Groups[2].Value.ToUpperInvariant()}";
 
 				if(!hourToLottery.TryGetValue(hourKey, out var matchedLottery))
+					continue;
+
+				if(matchedLottery.Order == 9 && DateTime.Today.DayOfWeek is not (DayOfWeek.Saturday or DayOfWeek.Sunday))
 					continue;
 
 				// 2) Número dentro del mismo bloque: .ball h2

--- a/Views/Award/Index.cshtml
+++ b/Views/Award/Index.cshtml
@@ -34,8 +34,9 @@
                 <div class="btn-group shadow-sm" role="group">
 
                     <button type="button"
+                            id="refreshAwardsButton"
                             class="btn btn-primary d-flex align-items-center gap-2 px-3"
-                            onclick="location.href='@Url.Action("Create", "Award")'">
+                            onclick="startAwardsRefresh('@Url.Action("Create", "Award")')">
                         <span class="material-icons fs-5">sync</span>
                         <span class="d-none d-sm-inline">Actualizar</span>
                     </button>
@@ -50,6 +51,34 @@
 
                 </div>
             </div>
+        </div>
+    </div>
+
+
+    @if (TempData["SuccessMessage"] is string successMessage)
+    {
+        <div class="alert alert-success border-0 rounded-4 shadow-sm d-flex align-items-start gap-3" role="alert">
+            <span class="material-icons">check_circle</span>
+            <div>@successMessage</div>
+        </div>
+    }
+
+    @if (TempData["ErrorMessage"] is string errorMessage)
+    {
+        <div class="alert alert-warning border-0 rounded-4 shadow-sm d-flex align-items-start gap-3" role="alert">
+            <span class="material-icons">warning</span>
+            <div>
+                <div class="fw-semibold">La actualización automática no terminó correctamente.</div>
+                <div>@errorMessage</div>
+            </div>
+        </div>
+    }
+
+    <div id="refreshStatus" class="alert alert-info border-0 rounded-4 shadow-sm d-none align-items-start gap-3" role="status" aria-live="polite">
+        <div class="spinner-border spinner-border-sm mt-1" aria-hidden="true"></div>
+        <div>
+            <div class="fw-semibold">Actualizando premios desde las fuentes...</div>
+            <div class="small mb-0">Si alguna página externa no responde o cambia su formato, se mostrará un aviso y podrá revisar los resultados manualmente.</div>
         </div>
     </div>
 
@@ -274,6 +303,24 @@
                 <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
 
                 <script type="text/javascript">
+                    function startAwardsRefresh(url) {
+                    const button = document.getElementById('refreshAwardsButton');
+                    const status = document.getElementById('refreshStatus');
+
+                    if (button) {
+                    button.disabled = true;
+                    button.classList.add('disabled');
+                    }
+
+                    if (status) {
+                    status.classList.remove('d-none');
+                    status.classList.add('d-flex');
+                    status.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }
+
+                    window.location.href = url;
+                    }
+
                     function scrollToItem(id) {
                     const element = document.getElementById('flush-collapse-' + id);
                     if (element) {

--- a/Views/Credit/Index.cshtml
+++ b/Views/Credit/Index.cshtml
@@ -340,6 +340,7 @@
             document.addEventListener("DOMContentLoaded", function () {
                 const showLimitExceededModal = @((!string.IsNullOrWhiteSpace(ViewBag.LimitExceededClientName as string)).ToString().ToLower());
                 const showFortnightReminder = @(((ViewBag.ShowFortnightReminder as bool?) == true).ToString().ToLower());
+                const fortnightReminderKey = '@(ViewBag.FortnightReminderKey ?? string.Empty)';
 
                 if (showLimitExceededModal) {
                     const limitModalElement = document.getElementById("creditLimitAlertModal");
@@ -349,9 +350,12 @@
                     }
                 }
 
-                if (showFortnightReminder) {
+                if (showFortnightReminder && fortnightReminderKey) {
+                    const alreadyShown = localStorage.getItem(fortnightReminderKey) === "shown";
                     const fortnightModalElement = document.getElementById("fortnightCollectionModal");
-                    if (fortnightModalElement) {
+
+                    if (!alreadyShown && fortnightModalElement) {
+                        localStorage.setItem(fortnightReminderKey, "shown");
                         new bootstrap.Modal(fortnightModalElement).show();
                     }
                 }

--- a/Views/Credit/_Report.cshtml
+++ b/Views/Credit/_Report.cshtml
@@ -1,79 +1,154 @@
-﻿<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-<link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
-<link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
-<link rel="stylesheet" href="~/LaLlamaDelBosque.styles.css" asp-append-version="true" />
+﻿<link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
 
 @model IEnumerable<LaLlamaDelBosque.Models.Credit>
 
-@using System.Web;
-@using Microsoft.AspNetCore.Mvc;
+@using LaLlamaDelBosque.Utils
 
 @{
     ViewData["Title"] = "Créditos de Clientes";
 }
 
-<h1 class="display-4">@ViewData["Title"]</h1>
+<style>
+    @@page {
+        size: A4;
+        margin: 12mm 10mm;
+    }
 
-<div class="container">
-    <div class="row justify-content-md-center">
-        <div class="col-xl-10">
-            <div class="accordion" id="accordionFlushExample">
-                @foreach (var item in Model)
+    body {
+        color: #1f2937;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 11px;
+        line-height: 1.25;
+    }
+
+    .report-title {
+        font-size: 22px;
+        font-weight: 700;
+        margin: 0 0 12px;
+    }
+
+    .credit-report-client {
+        page-break-inside: auto;
+        break-inside: auto;
+        margin-bottom: 14px;
+    }
+
+    .client-title {
+        background: #f1f5f9;
+        border: 1px solid #cbd5e1;
+        border-bottom: 0;
+        font-size: 16px;
+        font-weight: 700;
+        margin: 0;
+        padding: 6px 8px;
+        page-break-after: avoid;
+        break-after: avoid;
+    }
+
+    .credit-report-table {
+        border-collapse: collapse;
+        margin: 0;
+        table-layout: fixed;
+        width: 100%;
+    }
+
+    .credit-report-table thead {
+        display: table-header-group;
+    }
+
+    .credit-report-table tfoot {
+        display: table-footer-group;
+    }
+
+    .credit-report-table tr {
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+
+    .credit-report-table th,
+    .credit-report-table td {
+        border: 1px solid #cbd5e1;
+        padding: 4px 5px;
+        vertical-align: top;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+
+    .col-id { width: 8%; }
+    .col-date { width: 15%; }
+    .col-time { width: 13%; }
+    .col-description { width: 34%; }
+    .col-amount { width: 15%; }
+    .col-cumulative { width: 15%; }
+
+    .money-cell {
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    .total-row td {
+        background: #f8fafc;
+        font-weight: 700;
+    }
+
+    .grand-total {
+        border: 1px solid #cbd5e1;
+        margin-top: 18px;
+        padding: 10px;
+        page-break-inside: avoid;
+        text-align: right;
+    }
+
+    .grand-total h2 {
+        font-size: 20px;
+        margin: 4px 0 0;
+    }
+</style>
+
+<h1 class="report-title">@ViewData["Title"]</h1>
+
+@foreach (var item in Model.OrderBy(c => c.Client.Name))
+{
+    var cumulative = 0D;
+    <section class="credit-report-client">
+        <h2 class="client-title">@item.Client.Name</h2>
+        <table class="credit-report-table">
+            <thead>
+                <tr>
+                    <th class="col-id">Id</th>
+                    <th class="col-date">Fecha</th>
+                    <th class="col-time">Hora</th>
+                    <th class="col-description">Descripción</th>
+                    <th class="col-amount money-cell">Precio</th>
+                    <th class="col-cumulative money-cell">Acumulado</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach(var line in item.CreditLines.OrderBy(l => l.CreatedDate).ThenBy(l => l.Id))
                 {
-                    var cumulative = 0D;
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th class="align-content-center" colspan="6"><h1>@item.Client.Name</h1></th>
-                            </tr>
-                            <tr>
-                                <th>Id</th>
-                                <th>Fecha</th>
-                                <th>Hora</th>
-                                <th>Descripción</th>
-                                <th>Precio</th>
-                                <th>Acumulado</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach(var line in item.CreditLines) 
-                            {
-                                <tr>
-                                    <td>@line.Id</td>
-                                    <td>@line.CreatedDate.ToShortDateString()</td>
-                                    <td>@line.CreatedDate.ToShortTimeString()</td>
-                                    <td>@line.Description</td>
-                                    <td>₡ @line.Amount</td>
-                                    <td class="table-active">@{cumulative += @line.Amount;}₡ @cumulative</td>
-                                </tr>
-                            }
-                            </tbody>
-                        <tfoot>
-                            <tr>
-                                <td colspan="4">
-                                </td>
-                                <td>Total</td>
-                                <td id="TotalSummary">₡ @item.CreditSummary.Total</td>
-                            </tr>
-                        </tfoot>
-                    </table>
+                    cumulative += line.Amount;
+                    <tr>
+                        <td>@line.Id</td>
+                        <td>@line.CreatedDate.ToShortDateString()</td>
+                        <td>@line.CreatedDate.ToShortTimeString()</td>
+                        <td>@line.Description</td>
+                        <td class="money-cell">@line.Amount.ToCRC()</td>
+                        <td class="money-cell">@cumulative.ToCRC()</td>
+                    </tr>
                 }
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th class="align-content-center">
-                                <h1>TOTAL</h1>
-                            </th>
-                        </tr>
-                        <tr>
-                            <th class="align-content-center">
-                                <hr />
-                                <h2>₡ @Model.Sum(m => m.CreditSummary.Total)</h2>
-                            </th>
-                        </tr>
-                    </thead>
-                </table>
-            </div>
-        </div>
-    </div>
+            </tbody>
+            <tfoot>
+                <tr class="total-row">
+                    <td colspan="4"></td>
+                    <td>Total</td>
+                    <td class="money-cell">@item.CreditSummary.Total.ToCRC()</td>
+                </tr>
+            </tfoot>
+        </table>
+    </section>
+}
+
+<div class="grand-total">
+    <strong>TOTAL GENERAL</strong>
+    <h2>@Model.Sum(m => m.CreditSummary.Total).ToCRC()</h2>
 </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -193,13 +193,12 @@
             </div>
             <div class="modal-body">
                 <ul class="home-updates-list mb-0">
-                    <li><span class="material-icons">dashboard_customize</span> Nuevo dashboard más moderno con mejor jerarquía visual.</li>
-                    <li><span class="material-icons">emoji_events</span> Alerta en Home cuando faltan premios del día.</li>
-                    <li><span class="material-icons">event_repeat</span> Recordatorios estratégicos de cobro en quincena.</li>
-                    <li><span class="material-icons">warning_amber</span> Alerta inmediata cuando un cliente empieza a exceder su límite.</li>
-                    <li><span class="material-icons">pin</span> Creador de papelitos mejorado con selector inteligente de números (00–99), rangos y reglas rápidas.</li>
-                    <li><span class="material-icons">content_copy</span> Flujo más ágil para copiar papelitos y continuar edición sin perder contexto.</li>
-                    <li><span class="material-icons">schedule</span>Se corrigió la hora exacta del sorteo de La Primera Tarde.</li>
+                    <li><span class="material-icons">schedule</span> Sorteos Nica actualizados: el sorteo de mediodía vuelve a las 11:00 AM y los horarios vigentes quedan 11:00 AM, 3:00 PM y 9:00 PM.</li>
+                    <li><span class="material-icons">event_available</span> Nica 6:00 PM ahora se maneja únicamente para sábados y domingos; entre semana ya no aparece disponible ni se procesa en la actualización automática.</li>
+                    <li><span class="material-icons">sync</span> Actualización de premios con mejor UX: al presionar Actualizar se muestra estado en progreso, se bloquea el botón y se informa si la carga terminó o si falló una fuente externa.</li>
+                    <li><span class="material-icons">warning_amber</span> Si el scraping de premios no se completa correctamente, ahora se muestra una alerta clara para revisar las fuentes oficiales y volver a intentar.</li>
+                    <li><span class="material-icons">notifications_active</span> Recordatorio de cobro quincenal menos invasivo: se muestra una sola vez por ventana de cobro en el navegador.</li>
+                    <li><span class="material-icons">picture_as_pdf</span> PDF de créditos rediseñado para impresión: mejor paginación, tablas compactas, montos formateados y menos riesgo de traslapes.</li>
                 </ul>
             </div>
         </div>
@@ -210,7 +209,7 @@
     <script>
         document.addEventListener("DOMContentLoaded", function () {
 
-            const currentVersion = "v1";
+            const currentVersion = "v2-nica-awards-collections-credit-pdf";
             const storageKey = "home_updates_modal_version";
 
             const seenVersion = localStorage.getItem(storageKey);

--- a/Views/Note/Create.cshtml
+++ b/Views/Note/Create.cshtml
@@ -19,7 +19,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Value" class="control-label">Valor</label>
-                <input asp-for="Value" class="form-control" rows="3"></input>
+                <input asp-for="Value" class="form-control" />
                 <span asp-validation-for="Value" class="text-danger" id="description"></span>
             </div>
             <hr />

--- a/Views/Note/Edit.cshtml
+++ b/Views/Note/Edit.cshtml
@@ -11,15 +11,16 @@
 <div class="row">
     <div class="col-md-4">
         <form asp-action="Edit">
+            <input asp-for="Id" type="hidden" />
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
-                <label asp-for="Title" class="control-label">Proveedor</label>
+                <label asp-for="Title" class="control-label">Cliente</label>
                 <input asp-for="Title" class="form-control" />
                 <span asp-validation-for="Title" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Value" class="control-label">Productos</label>
-                <textarea asp-for="Value" class="form-control" rows="3"></textarea>
+                <label asp-for="Value" class="control-label">Valor</label>
+                <input asp-for="Value" class="form-control" />
                 <span asp-validation-for="Value" class="text-danger"></span>
             </div>
             <hr />

--- a/Views/Note/Index.cshtml
+++ b/Views/Note/Index.cshtml
@@ -1,59 +1,133 @@
 ﻿<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
 @model IEnumerable<LaLlamaDelBosque.Models.Note>
+@using LaLlamaDelBosque.Utils
 
 @{
     ViewData["Title"] = "Notas de pedidos";
 }
 
-<h1 class="display-4">@ViewData["Title"]</h1>
+<div class="container py-3">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+        <div>
+            <h1 class="display-6 mb-1">@ViewData["Title"]</h1>
+            <p class="text-muted mb-0">Administra los SINPEs o apuntes rápidos de clientes.</p>
+        </div>
 
+        <button type="button" class="btn btn-primary d-inline-flex align-items-center gap-2"
+                onclick="location.href='@Url.Action("Create", "Note")'">
+            <span class="material-icons">add_circle</span>
+            Crear nota
+        </button>
+    </div>
 
-<!-- Add -->
-<button type="button" class="btn"
-        onclick="location.href='@Url.Action("Create", "Note")'">
-    <span class="material-icons icon icon-primary">add_circle</span>
-</button>
+    <form asp-controller="Note" asp-action="Index" method="get" class="mb-3">
+        <div class="input-group shadow-sm">
+            <input type="search" name="searchText" class="form-control" value="@ViewBag.SearchText" placeholder="Buscar por cliente..." />
+            <button class="btn btn-outline-primary" type="submit">Buscar</button>
+            @if(!string.IsNullOrWhiteSpace(ViewBag.SearchText as string))
+            {
+                <a class="btn btn-outline-secondary" asp-controller="Note" asp-action="Index">Limpiar</a>
+            }
+        </div>
+    </form>
 
-@if(Model.Any() && TempData["Method"] is not null && Model.FirstOrDefault(x => x.Id == (int)TempData["Id"]) is not null)
-{
-    @switch(TempData["Method"])
+    @if(TempData["SuccessMessage"] is string successMessage)
     {
-        case "Delete":
-            @Html.Partial("_Delete", Model.FirstOrDefault(n => n.Id == (int)TempData["Id"]))
-            ;
-            break;
+        <div class="alert alert-success border-0 shadow-sm" role="alert">@successMessage</div>
     }
-}
 
-<div class="container">
-    <div class="d-flex justify-content-around flex-wrap">
+    @if(!Model.Any())
+    {
+        <div class="alert alert-info border-0 shadow-sm" role="alert">
+            No hay notas registradas todavía. Cree una nota para empezar.
+        </div>
+    }
+
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
         @foreach(var item in Model)
         {
-            <div class="card" style="width: 20rem; margin-bottom: 6px; margin-top: 12px;">
-                    <div class="card-header">
-                    <h5 class="card-title">@item.Title | ₡ @item.Value</h5>
-                    </div>
+            <div class="col">
+                <div class="card h-100 shadow-sm" id="note-card-@item.Id">
                     <div class="card-body">
-                        <div class="btn-group mx-auto" role="group">
-                            <!-- Edit -->
-                            <button type="button" class="btn"
-                                onclick="location.href='@Url.Action("Edit", "Note", new {Id= item.Id})'">
-                                <span class="material-icons icon icon-dark">edit</span>
+                        <div class="d-flex justify-content-between gap-3">
+                            <div>
+                                <div class="small text-muted text-uppercase">Cliente</div>
+                                <h5 class="card-title mb-1">@item.Title</h5>
+                            </div>
+                            <span class="badge text-bg-primary align-self-start">@item.Value.ToCRC()</span>
+                        </div>
+                    </div>
+                    <div class="card-footer bg-white border-0 pt-0">
+                        <div class="btn-group w-100" role="group" aria-label="Acciones de nota">
+                            <button type="button" class="btn btn-outline-dark"
+                                    onclick="location.href='@Url.Action("Edit", "Note", new { id = item.Id })'">
+                                <span class="material-icons">edit</span>
                             </button>
-                            <!-- Delete -->
-                            <button type="button" class="btn"
-                                onclick="location.href='@Url.Action("Delete", "Note", new {Id= item.Id})'">
-                                <span class="material-icons icon icon-danger">delete</span>
+                            <button type="button" class="btn btn-outline-danger"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#deleteNoteModal-@item.Id">
+                                <span class="material-icons">delete</span>
                             </button>
-                            <!-- Image -->
-                            <button type="button" class="btn"
-                                onclick="location.href='@Url.Action("Delete", "Note", new {Id= item.Id})'">
-                                <span class="material-icons icon icon-danger">image</span>
+                            <button type="button" class="btn btn-outline-primary"
+                                    onclick="copyNoteAsImage('@item.Id')">
+                                <span class="material-icons">image</span>
                             </button>
                         </div>
                     </div>
                 </div>
-            }
-        </div>
+            </div>
+
+            <div class="modal fade" id="deleteNoteModal-@item.Id" tabindex="-1" aria-labelledby="deleteNoteModalLabel-@item.Id" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content border-0 shadow">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="deleteNoteModalLabel-@item.Id">Eliminar nota</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <partial name="_Delete" model="item"></partial>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
 </div>
+
+<div class="modal fade" id="copySuccessModal" tabindex="-1" aria-labelledby="copySuccessModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content border-0 shadow">
+            <div class="modal-body text-center py-4">
+                <span class="material-icons text-success mb-2" style="font-size: 32px;">check_circle</span>
+                <h6 class="mb-0" id="copySuccessModalLabel">¡Imagen copiada!</h6>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
+    <script type="text/javascript">
+        function copyNoteAsImage(id) {
+            const card = document.getElementById('note-card-' + id);
+            if (!card) return;
+
+            html2canvas(card).then(function(canvas) {
+                canvas.toBlob(function(blob) {
+                    if (!blob || !navigator.clipboard || !navigator.clipboard.write) return;
+
+                    navigator.clipboard.write([
+                        new ClipboardItem({ "image/png": blob })
+                    ]).then(function() {
+                        const modal = new bootstrap.Modal(document.getElementById('copySuccessModal'));
+                        modal.show();
+                        setTimeout(function() { modal.hide(); }, 1800);
+                    }).catch(function(error) {
+                        console.error('Error al copiar la nota como imagen:', error);
+                    });
+                });
+            });
+        }
+    </script>
+}

--- a/Views/Note/_Delete.cshtml
+++ b/Views/Note/_Delete.cshtml
@@ -1,7 +1,10 @@
 ﻿@model LaLlamaDelBosque.Models.Note
 
-<h6>¿Desea eliminar la lista de @Model.Title?</h6>
+<h6>¿Desea eliminar la nota de @Model.Title?</h6>
+<p class="text-muted mb-3">Esta acción no se puede deshacer.</p>
 
-<form asp-action="Delete" asp-route-id=@Model.Id>
+<form asp-action="Delete" asp-route-id="@Model.Id" method="post">
+    @Html.AntiForgeryToken()
     <input type="submit" value="Eliminar" class="btn btn-danger" />
+    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
 </form>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -26,9 +26,9 @@
 @*                        <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Schedule" asp-action="Index">Horarios</a>
                         </li>*@
-                        <li class="nav-item">
+@*                        <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Note" asp-action="Index">Notas / SINPEs</a>
-                        </li>
+                        </li>*@
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 Tiempos

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -26,9 +26,9 @@
 @*                        <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Schedule" asp-action="Index">Horarios</a>
                         </li>*@
-@*                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Note" asp-action="Index">Sinpes</a>
-                        </li>*@
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-controller="Note" asp-action="Index">Notas / SINPEs</a>
+                        </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 Tiempos


### PR DESCRIPTION
### Motivation

- Ajustar la configuración y el scraping de los sorteos NICA para reflejar el cambio de horario solicitado y la restricción de días para el sorteo de las 6:00 PM.
- Mejorar la experiencia de usuario al ejecutar la actualización automática mostrando estado en progreso y mensajes claros al finalizar o fallar el scraping.

### Description

- Cambiado el sorteo de mediodía NICA de `12:00 PM` a `11:00 AM` en `Data/Lotteries.json` y `Data/ScrapingLotteries.json` para que la configuración y el mapeo de scraping coincidan con el horario actualizado.
- Limitado `NICA 6 PM` en `Data/Lotteries.json` para que tenga `"Days": ["Saturday","Sunday"]` y actualizado el scraper `Services/Scrapers/NicaraguaLotoDiariaScraper.cs` para omitir el resultado de 6PM en días de semana.
- Agregados mensajes de éxito/advertencia en `Controllers/AwardController.cs` para que la acción de actualización informe cuántos resultados se registraron o muestre un error legible.
- Mejorada la UI en `Views/Award/Index.cshtml` para deshabilitar el botón `Actualizar` durante la operación, mostrar un estado con spinner mientras se actualiza y presentar alertas de éxito/error al finalizar, además de agregar la función JavaScript `startAwardsRefresh`.

### Testing

- Ejecutado `git diff --check` sin errores en los cambios realizados.
- Intentado `dotnet build` pero no se completó porque el comando `dotnet` no está disponible en el entorno de ejecución; no se pudieron ejecutar builds ni pruebas automatizadas.
- Verificados cambios de archivos y commit local realizados en la rama con `git status` y `git show`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309bf6911c8330bff8685c4046a86a)