### PR TITLE
Fix Nica plain-text busted multiplier parsing

### DIFF
--- a/Services/Scrapers/NicaraguaLotoDiariaScraper.cs
+++ b/Services/Scrapers/NicaraguaLotoDiariaScraper.cs
@@ -10,7 +10,7 @@ namespace LaLlamaDelBosque.Services.Scrapers
 		private static readonly Regex TwoDigits = new(@"^\d{2}$", RegexOptions.Compiled);
 		private static readonly Regex SorteoHour = new(@"SORTEO\s+(\d{1,2})\s*([AP]M)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 		private static readonly Regex MultiXRegex =	new(@"\(Multi\s*X\)\s*=\s*([A-Za-z0-9]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-		private static readonly Regex PostedResult = new(@"SORTEO\s+(\d{1,2})\s*([AP]M)\s+(\d{2}|XX|[-—]+).*?\(M[aá]s\s*1\)\s*=.*?(?:[│|]\s*)?\(Multi\s*X\)\s*=\s*([A-Za-z0-9—-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		private static readonly Regex PostedResult = new(@"SORTEO\s+(\d{1,2})\s*([AP]M)\s+(\d{2}|XX|[-—]+).*?\(M[aá]s\s*1\)\s*=\s*([A-Za-z0-9—-]+).*?(?:[│|]\s*)?\(Multi\s*X\)\s*=\s*([A-Za-z0-9—-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 		public NicaraguaLotoDiariaScraper(HttpClient httpClient)
 			: base(httpClient, "https://nicatiempos.com/")
@@ -125,11 +125,11 @@ namespace LaLlamaDelBosque.Services.Scrapers
 
 				var order = matchedLottery.Order;
 				var description = orderToName.TryGetValue(order, out var name) ? name : string.Empty;
-				var multiX = match.Groups[4].Value.ToUpperInvariant();
-				var isBusted = Constants.BustedList.Contains(multiX) || Constants.NicaBustedMultipliers.ContainsKey(multiX);
+				var mas1 = match.Groups[4].Value.ToUpperInvariant();
+				var isBusted = Constants.BustedList.Contains(mas1) || Constants.NicaBustedMultipliers.ContainsKey(mas1);
 				double? timesBusted = null;
 
-				if(Constants.NicaBustedMultipliers.TryGetValue(multiX, out var mappedTimesBusted))
+				if(Constants.NicaBustedMultipliers.TryGetValue(mas1, out var mappedTimesBusted))
 					timesBusted = mappedTimesBusted;
 
 				var line = CreateAwardLine(order, description, numberText, isBusted, papers, timesBusted);


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the plain-text fallback discarded the `(Más 1)` token and therefore failed to mark busted Nicaragua draws, causing busted results to be treated as normal payouts.

### Description
- Update the `PostedResult` regex in `Services/Scrapers/NicaraguaLotoDiariaScraper.cs` to capture the `(Más 1)` value before the `(Multi X)` token so both values are available for parsing.
- Change `ProcessPlainText` to use the captured `(Más 1)` group (renamed `mas1`) when computing `isBusted` and looking up `NicaBustedMultipliers`, so busted markers like `3X` are recognized correctly.
- Performed the code update and committed the change to the branch (`Services/Scrapers/NicaraguaLotoDiariaScraper.cs`).

### Testing
- Attempted to run the test suite with `dotnet test` but the `dotnet` CLI is not installed in this environment so automated tests could not be executed here; please run `dotnet test` in CI or a dev environment to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c7fab7000833097f5661b78525d1b)