### PR TITLE
Fix lottery date filtering for paper creation

### DIFF
--- a/Controllers/LotteryController.cs
+++ b/Controllers/LotteryController.cs
@@ -546,10 +546,12 @@ namespace LaLlamaDelBosque.Controllers
 
 		private void UpdateLotteries(DateTime date)
 		{
+			var drawDate = date.Date;
+			var isToday = drawDate == DateTime.Today;
+
 			_lotteries = _lotteries
-				.Where(l => (date.ToShortDateString() == DateTime.Today.ToShortDateString() ?
-							 l.Hour.Add(TimeSpan.FromMinutes(-10)) > DateTime.Now.TimeOfDay : true) &&
-							(l.Days?.Contains(date.DayOfWeek.ToString()) ?? true))
+				.Where(l => (!isToday || l.Hour.Add(TimeSpan.FromMinutes(-10)) > DateTime.Now.TimeOfDay) &&
+							(l.Days?.Contains(drawDate.DayOfWeek.ToString()) ?? true))
 				.OrderBy(l => l.Hour)
 				.ToList();
 		}

--- a/Views/Lottery/Create.cshtml
+++ b/Views/Lottery/Create.cshtml
@@ -496,6 +496,10 @@
 
             if (!drawDate || !dropdown) return;
 
+            const previousSelected = [
+                ...dropdown.querySelectorAll('input[name="SelectedLotteries"]:checked')
+            ].map(cb => cb.value);
+
             const hasData =
                 stagedNumbers.length > 0 ||
                 ($("#bulkNumbersInput").val() || "").trim() !== "";


### PR DESCRIPTION
### Motivation
- The paper-creation flow failed when changing the draw date (e.g. to mañana) because the client-side code referenced a selection variable that could be undefined and lost previously selected lotteries. 
- The server-side lottery filtering used a string/date comparison that applied the "today" hour cutoff to other dates, preventing lotteries on future dates from appearing when they should.

### Description
- Preserve the previously checked lotteries in `Views/Lottery/Create.cshtml` by capturing `previousSelected` before rebuilding the dropdown during `loadLotteriesByDate()` to avoid JS errors and keep the selection when changing dates. 
- Update `Controllers/LotteryController.cs` `UpdateLotteries(DateTime date)` to use `date.Date` and an `isToday` flag so the 10-minute time cutoff is applied only for the current day and not for future dates. 
- Changes applied to `Views/Lottery/Create.cshtml` and `Controllers/LotteryController.cs` and committed as "Fix lottery date filtering for paper creation".

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted `dotnet build LaLlamaDelBosque.sln` but the build could not be executed because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ca8232b7883309cba7e7bc900a8ee)