### PR TITLE
Add payment method and shift-date filtering; revamp Note UI and schedule turn date support

### DIFF
--- a/Controllers/NoteController.cs
+++ b/Controllers/NoteController.cs
@@ -9,17 +9,19 @@ namespace LaLlamaDelBosque.Controllers
     public class NoteController: Controller
     {
         private readonly NoteModel _notes;
+        private readonly CashRegisterModel _cashRegister;
 
         public NoteController()
         {
             _notes = GetNotes();
+            _cashRegister = GetCashRegister();
         }
 
         public IActionResult Index(string? searchText, DateTime? shiftDate, NotePaymentMethod? paymentMethod)
         {
             var selectedDate = shiftDate?.Date ?? DateTime.Today;
-            var notes = _notes.Notes.AsEnumerable()
-                .Where(n => n.ShiftDate.Date == selectedDate);
+            var dayNotes = _notes.Notes.Where(n => n.ShiftDate.Date == selectedDate).ToList();
+            var notes = dayNotes.AsEnumerable();
 
             if(!string.IsNullOrWhiteSpace(searchText))
                 notes = notes.Where(n => n.Title.Contains(searchText, StringComparison.OrdinalIgnoreCase));
@@ -38,6 +40,9 @@ namespace LaLlamaDelBosque.Controllers
             ViewBag.SinpeTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.SINPE).Sum(n => n.Value);
             ViewBag.CardTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.Tarjeta).Sum(n => n.Value);
             ViewBag.GrandTotal = filteredNotes.Sum(n => n.Value);
+            ViewBag.PendingVerificationCount = dayNotes.Count(n => !n.IsVerified);
+            ViewBag.AllPaymentsVerified = dayNotes.All(n => n.IsVerified);
+            ViewBag.CashClose = _cashRegister.CashClosings.FirstOrDefault(c => c.ShiftDate.Date == selectedDate) ?? new CashRegisterClose { ShiftDate = selectedDate };
             return View(filteredNotes);
         }
 
@@ -86,6 +91,7 @@ namespace LaLlamaDelBosque.Controllers
             note.Value = model.Value;
             note.PaymentMethod = model.PaymentMethod;
             note.ShiftDate = model.ShiftDate.Date;
+            note.IsVerified = model.IsVerified;
             SetNotes(_notes);
             TempData["SuccessMessage"] = "Nota actualizada correctamente.";
             return RedirectToAction(nameof(Index), new { shiftDate = model.ShiftDate.ToString("yyyy-MM-dd") });
@@ -104,9 +110,94 @@ namespace LaLlamaDelBosque.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult ToggleVerified(int id, DateTime shiftDate)
+        {
+            var note = _notes.Notes.FirstOrDefault(n => n.Id == id);
+            if(note is null)
+                return NotFound();
+
+            note.IsVerified = !note.IsVerified;
+            SetNotes(_notes);
+            return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult SaveCashClose(IFormCollection collection)
+        {
+            var shiftDate = DateTime.Parse(collection["shiftDate"]);
+            var shiftPayments = _notes.Notes.Where(n => n.ShiftDate.Date == shiftDate.Date).ToList();
+            if(shiftPayments.Any(n => !n.IsVerified))
+            {
+                TempData["ErrorMessage"] = "No puede hacer cambio de turno: hay pagos SINPE/Tarjeta sin check de comprobación.";
+                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+            }
+
+            var cashClose = _cashRegister.CashClosings.FirstOrDefault(c => c.ShiftDate.Date == shiftDate.Date);
+            if(cashClose is null)
+            {
+                cashClose = new CashRegisterClose
+                {
+                    Id = _cashRegister.CashClosings.Any() ? _cashRegister.CashClosings.Max(c => c.Id) + 1 : 1,
+                    ShiftDate = shiftDate.Date
+                };
+                _cashRegister.CashClosings.Add(cashClose);
+            }
+
+            cashClose.InitialCash = ParseMoney(collection["initialCash"]);
+            cashClose.CashReceived = ParseMoney(collection["cashReceived"]);
+            cashClose.FinalCash = ParseMoney(collection["finalCash"]);
+            cashClose.BankDeposit = ParseMoney(collection["bankDeposit"]);
+            cashClose.PrizePayments = ParseMoney(collection["prizePayments"]);
+            cashClose.AccountsReceivable = ParseMoney(collection["accountsReceivable"]);
+            cashClose.Providers = BuildProviders(collection);
+
+            if(!cashClose.IsBalanced)
+            {
+                TempData["ErrorMessage"] = $"La caja no cuadra. Diferencia: {cashClose.Difference.ToCRC()}. Revise efectivo, premios y proveedores.";
+                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+            }
+
+            SetCashRegister(_cashRegister);
+            TempData["SuccessMessage"] = "Caja guardada correctamente. Ya puede hacer el cambio de turno.";
+            return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+        }
+
         public IActionResult Search(SearchModel srcModel)
         {
             return RedirectToAction(nameof(Index), new { searchText = srcModel.SearchText });
+        }
+
+        private static List<ProviderExpense> BuildProviders(IFormCollection collection)
+        {
+            var names = collection["providerNames"];
+            var amounts = collection["providerAmounts"];
+            var providers = new List<ProviderExpense>();
+
+            for(var index = 0; index < Math.Max(names.Count, amounts.Count); index++)
+            {
+                var name = index < names.Count ? names[index] ?? "" : "";
+                var amount = index < amounts.Count ? ParseMoney(amounts[index]) : 0;
+                if(!string.IsNullOrWhiteSpace(name) || amount > 0)
+                {
+                    providers.Add(new ProviderExpense { Name = name, Amount = amount });
+                }
+            }
+
+            return providers;
+        }
+
+        private static double ParseMoney(string? value)
+        {
+            if(string.IsNullOrWhiteSpace(value))
+                return 0;
+
+            var sanitized = value.Replace("₡", "").Replace(",", "").Trim();
+            return double.TryParse(sanitized, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var amount)
+                ? amount
+                : 0;
         }
 
         private static NoteModel GetNotes()
@@ -122,6 +213,16 @@ namespace LaLlamaDelBosque.Controllers
         private static void SetNotes(NoteModel notes)
         {
             JsonFile.Write<NoteModel>("Notes", notes);
+        }
+
+        private static CashRegisterModel GetCashRegister()
+        {
+            return JsonFile.Read<CashRegisterModel>("CashRegister", new CashRegisterModel());
+        }
+
+        private static void SetCashRegister(CashRegisterModel cashRegister)
+        {
+            JsonFile.Write<CashRegisterModel>("CashRegister", cashRegister);
         }
     }
 }

--- a/Controllers/NoteController.cs
+++ b/Controllers/NoteController.cs
@@ -15,21 +15,36 @@ namespace LaLlamaDelBosque.Controllers
             _notes = GetNotes();
         }
 
-        public IActionResult Index(string? searchText)
+        public IActionResult Index(string? searchText, DateTime? shiftDate, NotePaymentMethod? paymentMethod)
         {
-            var notes = _notes.Notes.AsEnumerable();
+            var selectedDate = shiftDate?.Date ?? DateTime.Today;
+            var notes = _notes.Notes.AsEnumerable()
+                .Where(n => n.ShiftDate.Date == selectedDate);
 
             if(!string.IsNullOrWhiteSpace(searchText))
                 notes = notes.Where(n => n.Title.Contains(searchText, StringComparison.OrdinalIgnoreCase));
 
+            if(paymentMethod.HasValue)
+                notes = notes.Where(n => n.PaymentMethod == paymentMethod.Value);
+
+            var filteredNotes = notes
+                .OrderBy(n => n.PaymentMethod)
+                .ThenBy(n => n.Title)
+                .ToList();
+
             ViewBag.SearchText = searchText;
-            return View(notes.OrderBy(n => n.Title).ToList());
+            ViewBag.ShiftDate = selectedDate.ToString("yyyy-MM-dd");
+            ViewBag.PaymentMethod = paymentMethod;
+            ViewBag.SinpeTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.SINPE).Sum(n => n.Value);
+            ViewBag.CardTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.Tarjeta).Sum(n => n.Value);
+            ViewBag.GrandTotal = filteredNotes.Sum(n => n.Value);
+            return View(filteredNotes);
         }
 
         [HttpGet]
         public IActionResult Create()
         {
-            return View(new Note());
+            return View(new Note { ShiftDate = DateTime.Today });
         }
 
         [HttpPost]
@@ -43,7 +58,7 @@ namespace LaLlamaDelBosque.Controllers
             _notes.Notes.Add(model);
             SetNotes(_notes);
             TempData["SuccessMessage"] = "Nota creada correctamente.";
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), new { shiftDate = model.ShiftDate.ToString("yyyy-MM-dd") });
         }
 
         [HttpGet]
@@ -69,9 +84,11 @@ namespace LaLlamaDelBosque.Controllers
 
             note.Title = model.Title;
             note.Value = model.Value;
+            note.PaymentMethod = model.PaymentMethod;
+            note.ShiftDate = model.ShiftDate.Date;
             SetNotes(_notes);
             TempData["SuccessMessage"] = "Nota actualizada correctamente.";
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), new { shiftDate = model.ShiftDate.ToString("yyyy-MM-dd") });
         }
 
         [HttpPost]
@@ -95,6 +112,10 @@ namespace LaLlamaDelBosque.Controllers
         private static NoteModel GetNotes()
         {
             var notes = JsonFile.Read<NoteModel>("Notes", new NoteModel());
+            foreach(var note in notes.Notes.Where(n => n.ShiftDate == default))
+            {
+                note.ShiftDate = DateTime.Today;
+            }
             return notes;
         }
 

--- a/Controllers/ScheduleController.cs
+++ b/Controllers/ScheduleController.cs
@@ -24,18 +24,20 @@ namespace LaLlamaDelBosque.Controllers
         }
 
         // GET: Schedule/Turn
-        public ActionResult Turn()
+        public ActionResult Turn(DateTime? shiftDate)
         {
+            var selectedDate = shiftDate?.Date ?? DateTime.Today;
             var schedules = _schedules.Schedules.Where(x =>
                 !x.IsCompleted &&
-                x.CreatedDate.Day == DateTime.Today.Day);
+                x.CreatedDate.Date == selectedDate);
 
             foreach(var schedule in schedules)
             {
                 schedule.FinishDate = DateTime.Now;
             }
 
-            return View(schedules);
+            ViewBag.ShiftDate = selectedDate.ToString("yyyy-MM-dd");
+            return View(schedules.OrderBy(s => s.CreatedDate));
         }
 
         // POST: Schedule/Turn
@@ -48,7 +50,7 @@ namespace LaLlamaDelBosque.Controllers
                 _schedules.Schedules.First(x => x.Id == id).FinishDate = DateTime.Now;
                 SetSchedules(_schedules);
             }
-            return RedirectToAction(nameof(Turn));
+            return RedirectToAction(nameof(Turn), new { shiftDate = schedule.CreatedDate.ToString("yyyy-MM-dd") });
         }
 
         // GET: Schedule/Create

--- a/Models/NoteModel.cs
+++ b/Models/NoteModel.cs
@@ -7,6 +7,12 @@ namespace LaLlamaDelBosque.Models
         public List<Note> Notes { get; set; } = new List<Note>();
     }
 
+    public enum NotePaymentMethod
+    {
+        SINPE = 1,
+        Tarjeta = 2
+    }
+
     public class Note
     {
         public int Id { get; set; }
@@ -18,5 +24,14 @@ namespace LaLlamaDelBosque.Models
         [Required(ErrorMessage = "El campo es requerido")]
         [Range(10, 1000000, ErrorMessage = "El valor debe estar entre {1} y {2}.")]
         public double Value { get; set; }
+
+        [Required(ErrorMessage = "El método de pago es requerido")]
+        [Display(Name = "Método de pago")]
+        public NotePaymentMethod PaymentMethod { get; set; } = NotePaymentMethod.SINPE;
+
+        [Required(ErrorMessage = "El día de turno es requerido")]
+        [DataType(DataType.Date)]
+        [Display(Name = "Día de turno")]
+        public DateTime ShiftDate { get; set; } = DateTime.Today;
     }
 }

--- a/Models/NoteModel.cs
+++ b/Models/NoteModel.cs
@@ -7,6 +7,36 @@ namespace LaLlamaDelBosque.Models
         public List<Note> Notes { get; set; } = new List<Note>();
     }
 
+    public class CashRegisterModel
+    {
+        public List<CashRegisterClose> CashClosings { get; set; } = new List<CashRegisterClose>();
+    }
+
+    public class CashRegisterClose
+    {
+        public int Id { get; set; }
+        public DateTime ShiftDate { get; set; } = DateTime.Today;
+
+        public double InitialCash { get; set; }
+        public double CashReceived { get; set; }
+        public double FinalCash { get; set; }
+        public double BankDeposit { get; set; }
+        public double PrizePayments { get; set; }
+        public double AccountsReceivable { get; set; }
+        public List<ProviderExpense> Providers { get; set; } = new List<ProviderExpense>();
+
+        public double ProviderTotal => Math.Round(Providers.Sum(p => p.Amount), 2);
+        public double ExpectedCash => Math.Round(InitialCash + CashReceived - ProviderTotal - PrizePayments, 2);
+        public double Difference => Math.Round(FinalCash - ExpectedCash, 2);
+        public bool IsBalanced => Math.Abs(Difference) < 0.01;
+    }
+
+    public class ProviderExpense
+    {
+        public string Name { get; set; } = "";
+        public double Amount { get; set; }
+    }
+
     public enum NotePaymentMethod
     {
         SINPE = 1,
@@ -33,5 +63,7 @@ namespace LaLlamaDelBosque.Models
         [DataType(DataType.Date)]
         [Display(Name = "Día de turno")]
         public DateTime ShiftDate { get; set; } = DateTime.Today;
+
+        public bool IsVerified { get; set; }
     }
 }

--- a/Views/Note/Create.cshtml
+++ b/Views/Note/Create.cshtml
@@ -1,39 +1,53 @@
 ﻿@model LaLlamaDelBosque.Models.Note
 
 @{
-    ViewData["Title"] = "Crear Nota";
+    ViewData["Title"] = "Registrar pago";
 }
 
-<h1 class="display-6">@ViewData["Title"]</h1>
+<div class="container py-3">
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body p-4">
+                    <h1 class="display-6 mb-1">@ViewData["Title"]</h1>
+                    <p class="text-muted mb-4">Agrega SINPEs o pagos con tarjeta al turno del día correcto.</p>
 
-<hr />
-
-<div class="row">
-    <div class="col-md-4">
-        <form asp-action="Create">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Title" class="control-label">Cliente</label>
-                <input asp-for="Title" class="form-control" id="title" />
-                <span asp-validation-for="Title" class="text-danger"></span>
+                    <form asp-action="Create">
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="mb-3">
+                            <label asp-for="Title" class="form-label">Cliente</label>
+                            <input asp-for="Title" class="form-control form-control-lg" id="title" placeholder="Nombre del cliente" />
+                            <span asp-validation-for="Title" class="text-danger"></span>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label asp-for="Value" class="form-label">Monto</label>
+                                <input asp-for="Value" class="form-control form-control-lg" inputmode="decimal" placeholder="₡" />
+                                <span asp-validation-for="Value" class="text-danger" id="description"></span>
+                            </div>
+                            <div class="col-md-6">
+                                <label asp-for="PaymentMethod" class="form-label">Método</label>
+                                <select asp-for="PaymentMethod" asp-items="Html.GetEnumSelectList<NotePaymentMethod>()" class="form-select form-select-lg"></select>
+                                <span asp-validation-for="PaymentMethod" class="text-danger"></span>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <label asp-for="ShiftDate" class="form-label">Turno / día</label>
+                            <input asp-for="ShiftDate" type="date" class="form-control form-control-lg" />
+                            <span asp-validation-for="ShiftDate" class="text-danger"></span>
+                        </div>
+                        <hr />
+                        <div class="d-flex justify-content-between align-items-center">
+                            <a asp-action="Index" class="btn btn-outline-secondary">Volver</a>
+                            <input type="submit" value="Guardar pago" class="btn btn-primary btn-lg" />
+                        </div>
+                    </form>
+                </div>
             </div>
-            <div class="form-group">
-                <label asp-for="Value" class="control-label">Valor</label>
-                <input asp-for="Value" class="form-control" />
-                <span asp-validation-for="Value" class="text-danger" id="description"></span>
-            </div>
-            <hr />
-            <div class="form-group">
-                <input type="submit" value="Crear" class="btn btn-primary" />
-                &nbsp;&nbsp;&nbsp;
-                <a asp-action="Index" style="color: var(--dark);">Volver</a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    @{
-        await Html.RenderPartialAsync("_ValidationScriptsPartial");
-    }
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }

--- a/Views/Note/Edit.cshtml
+++ b/Views/Note/Edit.cshtml
@@ -1,40 +1,54 @@
 ﻿@model LaLlamaDelBosque.Models.Note
 
 @{
-    ViewData["Title"] = "Editar Nota";
+    ViewData["Title"] = "Editar pago";
 }
 
-<h1 class="display-6">@ViewData["Title"]</h1>
+<div class="container py-3">
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body p-4">
+                    <h1 class="display-6 mb-1">@ViewData["Title"]</h1>
+                    <p class="text-muted mb-4">Ajusta el cliente, monto, método o día de turno.</p>
 
-<hr />
-
-<div class="row">
-    <div class="col-md-4">
-        <form asp-action="Edit">
-            <input asp-for="Id" type="hidden" />
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Title" class="control-label">Cliente</label>
-                <input asp-for="Title" class="form-control" />
-                <span asp-validation-for="Title" class="text-danger"></span>
+                    <form asp-action="Edit">
+                        <input asp-for="Id" type="hidden" />
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="mb-3">
+                            <label asp-for="Title" class="form-label">Cliente</label>
+                            <input asp-for="Title" class="form-control form-control-lg" />
+                            <span asp-validation-for="Title" class="text-danger"></span>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label asp-for="Value" class="form-label">Monto</label>
+                                <input asp-for="Value" class="form-control form-control-lg" inputmode="decimal" />
+                                <span asp-validation-for="Value" class="text-danger"></span>
+                            </div>
+                            <div class="col-md-6">
+                                <label asp-for="PaymentMethod" class="form-label">Método</label>
+                                <select asp-for="PaymentMethod" asp-items="Html.GetEnumSelectList<NotePaymentMethod>()" class="form-select form-select-lg"></select>
+                                <span asp-validation-for="PaymentMethod" class="text-danger"></span>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <label asp-for="ShiftDate" class="form-label">Turno / día</label>
+                            <input asp-for="ShiftDate" type="date" class="form-control form-control-lg" />
+                            <span asp-validation-for="ShiftDate" class="text-danger"></span>
+                        </div>
+                        <hr />
+                        <div class="d-flex justify-content-between align-items-center">
+                            <a asp-action="Index" asp-route-shiftDate="@Model.ShiftDate.ToString("yyyy-MM-dd")" class="btn btn-outline-secondary">Volver</a>
+                            <input type="submit" value="Guardar cambios" class="btn btn-primary btn-lg" />
+                        </div>
+                    </form>
+                </div>
             </div>
-            <div class="form-group">
-                <label asp-for="Value" class="control-label">Valor</label>
-                <input asp-for="Value" class="form-control" />
-                <span asp-validation-for="Value" class="text-danger"></span>
-            </div>
-            <hr />
-            <div class="form-group">
-                <input type="submit" value="Editar" class="btn btn-primary" />
-                &nbsp;&nbsp;&nbsp;
-                <a asp-action="Index" style="color: var(--dark);">Volver</a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-    @{
-        await Html.RenderPartialAsync("_ValidationScriptsPartial");
-    }
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }

--- a/Views/Note/Index.cshtml
+++ b/Views/Note/Index.cshtml
@@ -12,6 +12,9 @@
     var dateTitle = DateTime.TryParse(selectedDate, out var parsedShiftDate)
         ? parsedShiftDate.ToString("dd-MMM", System.Globalization.CultureInfo.InvariantCulture)
         : selectedDate;
+    var cashClose = ViewBag.CashClose as CashRegisterClose ?? new CashRegisterClose();
+    var providerRows = Math.Max(11, cashClose.Providers.Count);
+    var canCloseShift = (bool)(ViewBag.AllPaymentsVerified ?? false);
 }
 
 <div class="container py-3">
@@ -126,7 +129,19 @@
                                 <td class="sheet-number">@(index + 1)</td>
                                 <td class="sheet-money">@(row is null ? "" : row.Value.ToCRC())</td>
                                 <td>@(row?.Title ?? "")</td>
-                                <td class="sheet-check">@(row is null ? "" : "✓")</td>
+                                <td class="sheet-check">
+                                    @if(row is not null)
+                                    {
+                                        <form asp-controller="Note" asp-action="ToggleVerified" method="post" class="m-0">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="id" value="@row.Id" />
+                                            <input type="hidden" name="shiftDate" value="@selectedDate" />
+                                            <button type="submit" class="sheet-check-button @(row.IsVerified ? "is-checked" : "")" aria-label="Marcar pago comprobado">
+                                                @(row.IsVerified ? "✓" : "")
+                                            </button>
+                                        </form>
+                                    }
+                                </td>
                             </tr>
                         }
                     </tbody>
@@ -140,6 +155,93 @@
                     </tfoot>
                 </table>
             </div>
+        </div>
+    </div>
+
+
+    @if(TempData["ErrorMessage"] is string errorMessage)
+    {
+        <div class="alert alert-danger border-0 shadow-sm" role="alert">@errorMessage</div>
+    }
+
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between gap-2 mb-3">
+                <div>
+                    <h2 class="h5 mb-1">Caja / cambio de turno</h2>
+                    <p class="text-muted mb-0">Los checks deben estar completos y la caja debe cuadrar para permitir el cambio de personal.</p>
+                </div>
+                @if(canCloseShift)
+                {
+                    <span class="badge text-bg-success align-self-start">Pagos comprobados</span>
+                }
+                else
+                {
+                    <span class="badge text-bg-danger align-self-start">@ViewBag.PendingVerificationCount sin comprobar</span>
+                }
+            </div>
+
+            <form asp-controller="Note" asp-action="SaveCashClose" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="shiftDate" value="@selectedDate" />
+                <div class="row g-3">
+                    <div class="col-md-4">
+                        <label class="form-label">Caja inicial</label>
+                        <input name="initialCash" class="form-control" inputmode="decimal" value="@cashClose.InitialCash" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Efectivo recibido</label>
+                        <input name="cashReceived" class="form-control" inputmode="decimal" value="@cashClose.CashReceived" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Caja final contada</label>
+                        <input name="finalCash" class="form-control" inputmode="decimal" value="@cashClose.FinalCash" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Banco</label>
+                        <input name="bankDeposit" class="form-control" inputmode="decimal" value="@cashClose.BankDeposit" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Pago premios</label>
+                        <input name="prizePayments" class="form-control" inputmode="decimal" value="@cashClose.PrizePayments" />
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">Cuentas por cobrar</label>
+                        <input name="accountsReceivable" class="form-control" inputmode="decimal" value="@cashClose.AccountsReceivable" />
+                    </div>
+                </div>
+
+                <div class="row g-4 mt-1">
+                    <div class="col-lg-7">
+                        <h3 class="h6 text-uppercase text-muted">Proveedores (gastos)</h3>
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle">
+                                <thead><tr><th>Proveedor</th><th style="width: 180px;">Monto</th></tr></thead>
+                                <tbody>
+                                    @for(var index = 0; index < providerRows; index++)
+                                    {
+                                        var provider = index < cashClose.Providers.Count ? cashClose.Providers[index] : new ProviderExpense();
+                                        <tr>
+                                            <td><input name="providerNames" class="form-control form-control-sm" value="@provider.Name" placeholder="Proveedor @(index + 1)" /></td>
+                                            <td><input name="providerAmounts" class="form-control form-control-sm" inputmode="decimal" value="@provider.Amount" /></td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="col-lg-5">
+                        <div class="list-group shadow-sm">
+                            <div class="list-group-item d-flex justify-content-between"><span>SINPEs comprobados</span><strong>@(((double)ViewBag.SinpeTotal).ToCRC())</strong></div>
+                            <div class="list-group-item d-flex justify-content-between"><span>Tarjetas comprobadas</span><strong>@(((double)ViewBag.CardTotal).ToCRC())</strong></div>
+                            <div class="list-group-item d-flex justify-content-between"><span>Suma proveedores</span><strong>@cashClose.ProviderTotal.ToCRC()</strong></div>
+                            <div class="list-group-item d-flex justify-content-between"><span>Caja esperada</span><strong>@cashClose.ExpectedCash.ToCRC()</strong></div>
+                            <div class="list-group-item d-flex justify-content-between @(cashClose.IsBalanced ? "list-group-item-success" : "list-group-item-warning")"><span>Diferencia</span><strong>@cashClose.Difference.ToCRC()</strong></div>
+                        </div>
+                        <button type="submit" class="btn btn-success w-100 mt-3" disabled="@(!canCloseShift)">Guardar caja y cambiar turno</button>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
 
@@ -167,7 +269,10 @@
                                 <div class="small text-muted text-uppercase">Cliente</div>
                                 <h5 class="card-title mb-0">@item.Title</h5>
                             </div>
-                            <span class="badge @badgeClass align-self-start">@item.PaymentMethod</span>
+                            <div class="d-flex flex-column align-items-end gap-1">
+                                <span class="badge @badgeClass align-self-start">@item.PaymentMethod</span>
+                                <span class="badge @(item.IsVerified ? "text-bg-success" : "text-bg-warning")">@(item.IsVerified ? "Comprobado" : "Pendiente")</span>
+                            </div>
                         </div>
                         <div class="d-flex justify-content-between align-items-end">
                             <div>
@@ -252,6 +357,19 @@
     .payment-sheet .sheet-total-value,
     .payment-sheet .sheet-check {
         text-align: center;
+    }
+
+    .sheet-check-button {
+        width: 1.5rem;
+        height: 1.5rem;
+        border: 1px solid #111;
+        background: #fff;
+        font-weight: 700;
+        line-height: 1;
+    }
+
+    .sheet-check-button.is-checked {
+        background: #63be7b;
     }
 </style>
 

--- a/Views/Note/Index.cshtml
+++ b/Views/Note/Index.cshtml
@@ -4,33 +4,144 @@
 @using LaLlamaDelBosque.Utils
 
 @{
-    ViewData["Title"] = "Notas de pedidos";
+    ViewData["Title"] = "Pagos del turno";
+    var selectedDate = ViewBag.ShiftDate as string ?? DateTime.Today.ToString("yyyy-MM-dd");
+    NotePaymentMethod? selectedMethod = ViewBag.PaymentMethod as NotePaymentMethod?;
+    var paymentRows = Model.ToList();
+    var spreadsheetRows = Math.Max(28, paymentRows.Count);
+    var dateTitle = DateTime.TryParse(selectedDate, out var parsedShiftDate)
+        ? parsedShiftDate.ToString("dd-MMM", System.Globalization.CultureInfo.InvariantCulture)
+        : selectedDate;
 }
 
 <div class="container py-3">
-    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
         <div>
             <h1 class="display-6 mb-1">@ViewData["Title"]</h1>
-            <p class="text-muted mb-0">Administra los SINPEs o apuntes rápidos de clientes.</p>
+            <p class="text-muted mb-0">Control diario de SINPEs y tarjetas, pensado para reemplazar el Excel del cierre de turno.</p>
         </div>
 
-        <button type="button" class="btn btn-primary d-inline-flex align-items-center gap-2"
+        <button type="button" class="btn btn-primary btn-lg d-inline-flex align-items-center gap-2"
                 onclick="location.href='@Url.Action("Create", "Note")'">
             <span class="material-icons">add_circle</span>
-            Crear nota
+            Registrar pago
         </button>
     </div>
 
-    <form asp-controller="Note" asp-action="Index" method="get" class="mb-3">
-        <div class="input-group shadow-sm">
-            <input type="search" name="searchText" class="form-control" value="@ViewBag.SearchText" placeholder="Buscar por cliente..." />
-            <button class="btn btn-outline-primary" type="submit">Buscar</button>
-            @if(!string.IsNullOrWhiteSpace(ViewBag.SearchText as string))
-            {
-                <a class="btn btn-outline-secondary" asp-controller="Note" asp-action="Index">Limpiar</a>
-            }
+    <form asp-controller="Note" asp-action="Index" method="get" class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Turno / día</label>
+                    <input type="date" name="shiftDate" class="form-control" value="@selectedDate" />
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label fw-semibold">Buscar cliente</label>
+                    <input type="search" name="searchText" class="form-control" value="@ViewBag.SearchText" placeholder="Nombre del cliente..." />
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Método</label>
+                    <select name="paymentMethod" class="form-select">
+                        <option value="">Todos</option>
+                        @if(selectedMethod == NotePaymentMethod.SINPE)
+                        {
+                            <option value="SINPE" selected>SINPE</option>
+                        }
+                        else
+                        {
+                            <option value="SINPE">SINPE</option>
+                        }
+                        @if(selectedMethod == NotePaymentMethod.Tarjeta)
+                        {
+                            <option value="Tarjeta" selected>Tarjeta</option>
+                        }
+                        else
+                        {
+                            <option value="Tarjeta">Tarjeta</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-2 d-grid">
+                    <button class="btn btn-dark" type="submit">Ver turno</button>
+                </div>
+            </div>
         </div>
     </form>
+
+    <div class="row g-3 mb-4">
+        <div class="col-md-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="small text-muted text-uppercase">Total SINPE</div>
+                    <div class="h3 mb-0 text-primary">@(((double)ViewBag.SinpeTotal).ToCRC())</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="small text-muted text-uppercase">Total Tarjeta</div>
+                    <div class="h3 mb-0 text-success">@(((double)ViewBag.CardTotal).ToCRC())</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card border-0 shadow-sm h-100 bg-dark text-white">
+                <div class="card-body">
+                    <div class="small text-white-50 text-uppercase">Total del turno</div>
+                    <div class="h3 mb-0">@(((double)ViewBag.GrandTotal).ToCRC())</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+                <div>
+                    <h2 class="h5 mb-1">Planilla del turno</h2>
+                    <p class="text-muted mb-0">Vista tipo Excel para revisar rápidamente montos, nombres y confirmación.</p>
+                </div>
+                <span class="badge text-bg-success fs-6">@dateTitle</span>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle payment-sheet mb-0">
+                    <thead>
+                        <tr>
+                            <th class="sheet-date" colspan="4">@dateTitle</th>
+                        </tr>
+                        <tr>
+                            <th class="sheet-number"></th>
+                            <th>monto</th>
+                            <th>Nombre</th>
+                            <th>Si</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for(var index = 0; index < spreadsheetRows; index++)
+                        {
+                            var row = index < paymentRows.Count ? paymentRows[index] : null;
+                            <tr>
+                                <td class="sheet-number">@(index + 1)</td>
+                                <td class="sheet-money">@(row is null ? "" : row.Value.ToCRC())</td>
+                                <td>@(row?.Title ?? "")</td>
+                                <td class="sheet-check">@(row is null ? "" : "✓")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td class="sheet-total-fill"></td>
+                            <td class="sheet-total-label">TOTAL</td>
+                            <td class="sheet-total-value">@(((double)ViewBag.GrandTotal).ToCRC())</td>
+                            <td class="sheet-total-fill"></td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+    </div>
 
     @if(TempData["SuccessMessage"] is string successMessage)
     {
@@ -40,37 +151,41 @@
     @if(!Model.Any())
     {
         <div class="alert alert-info border-0 shadow-sm" role="alert">
-            No hay notas registradas todavía. Cree una nota para empezar.
+            No hay pagos registrados para este turno. Cambia el día o registra el primer SINPE/tarjeta.
         </div>
     }
 
-    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3">
         @foreach(var item in Model)
         {
+            var badgeClass = item.PaymentMethod == NotePaymentMethod.SINPE ? "text-bg-primary" : "text-bg-success";
             <div class="col">
-                <div class="card h-100 shadow-sm" id="note-card-@item.Id">
+                <div class="card h-100 border-0 shadow-sm" id="note-card-@item.Id">
                     <div class="card-body">
-                        <div class="d-flex justify-content-between gap-3">
+                        <div class="d-flex justify-content-between gap-3 mb-3">
                             <div>
                                 <div class="small text-muted text-uppercase">Cliente</div>
-                                <h5 class="card-title mb-1">@item.Title</h5>
+                                <h5 class="card-title mb-0">@item.Title</h5>
                             </div>
-                            <span class="badge text-bg-primary align-self-start">@item.Value.ToCRC()</span>
+                            <span class="badge @badgeClass align-self-start">@item.PaymentMethod</span>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-end">
+                            <div>
+                                <div class="small text-muted">Turno</div>
+                                <div>@item.ShiftDate.ToShortDateString()</div>
+                            </div>
+                            <div class="h4 mb-0">@item.Value.ToCRC()</div>
                         </div>
                     </div>
                     <div class="card-footer bg-white border-0 pt-0">
-                        <div class="btn-group w-100" role="group" aria-label="Acciones de nota">
-                            <button type="button" class="btn btn-outline-dark"
-                                    onclick="location.href='@Url.Action("Edit", "Note", new { id = item.Id })'">
+                        <div class="btn-group w-100" role="group" aria-label="Acciones de pago">
+                            <button type="button" class="btn btn-outline-dark" onclick="location.href='@Url.Action("Edit", "Note", new { id = item.Id })'">
                                 <span class="material-icons">edit</span>
                             </button>
-                            <button type="button" class="btn btn-outline-danger"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#deleteNoteModal-@item.Id">
+                            <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteNoteModal-@item.Id">
                                 <span class="material-icons">delete</span>
                             </button>
-                            <button type="button" class="btn btn-outline-primary"
-                                    onclick="copyNoteAsImage('@item.Id')">
+                            <button type="button" class="btn btn-outline-primary" onclick="copyNoteAsImage('@item.Id')">
                                 <span class="material-icons">image</span>
                             </button>
                         </div>
@@ -82,7 +197,7 @@
                 <div class="modal-dialog modal-dialog-centered">
                     <div class="modal-content border-0 shadow">
                         <div class="modal-header">
-                            <h5 class="modal-title" id="deleteNoteModalLabel-@item.Id">Eliminar nota</h5>
+                            <h5 class="modal-title" id="deleteNoteModalLabel-@item.Id">Eliminar pago</h5>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
@@ -96,15 +211,49 @@
 </div>
 
 <div class="modal fade" id="copySuccessModal" tabindex="-1" aria-labelledby="copySuccessModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-sm modal-dialog-centered">
-        <div class="modal-content border-0 shadow">
-            <div class="modal-body text-center py-4">
-                <span class="material-icons text-success mb-2" style="font-size: 32px;">check_circle</span>
-                <h6 class="mb-0" id="copySuccessModalLabel">¡Imagen copiada!</h6>
-            </div>
-        </div>
-    </div>
+    <div class="modal-dialog modal-sm modal-dialog-centered"><div class="modal-content border-0 shadow"><div class="modal-body text-center py-4"><span class="material-icons text-success mb-2" style="font-size: 32px;">check_circle</span><h6 class="mb-0" id="copySuccessModalLabel">¡Imagen copiada!</h6></div></div></div>
 </div>
+
+<style>
+    .payment-sheet {
+        max-width: 420px;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+    }
+
+    .payment-sheet th,
+    .payment-sheet td {
+        border: 1px solid #111;
+        padding: 0.18rem 0.45rem;
+    }
+
+    .payment-sheet .sheet-date,
+    .payment-sheet thead th,
+    .payment-sheet .sheet-number,
+    .payment-sheet .sheet-total-fill {
+        background: #63be7b;
+        color: #000;
+        font-weight: 700;
+        text-align: center;
+    }
+
+    .payment-sheet tbody td:not(.sheet-number),
+    .payment-sheet .sheet-total-label,
+    .payment-sheet .sheet-total-value {
+        background: #d9ead3;
+    }
+
+    .payment-sheet .sheet-money,
+    .payment-sheet .sheet-total-value {
+        white-space: nowrap;
+    }
+
+    .payment-sheet .sheet-total-label,
+    .payment-sheet .sheet-total-value,
+    .payment-sheet .sheet-check {
+        text-align: center;
+    }
+</style>
 
 @section Scripts {
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
@@ -112,20 +261,14 @@
         function copyNoteAsImage(id) {
             const card = document.getElementById('note-card-' + id);
             if (!card) return;
-
             html2canvas(card).then(function(canvas) {
                 canvas.toBlob(function(blob) {
                     if (!blob || !navigator.clipboard || !navigator.clipboard.write) return;
-
-                    navigator.clipboard.write([
-                        new ClipboardItem({ "image/png": blob })
-                    ]).then(function() {
+                    navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]).then(function() {
                         const modal = new bootstrap.Modal(document.getElementById('copySuccessModal'));
                         modal.show();
                         setTimeout(function() { modal.hide(); }, 1800);
-                    }).catch(function(error) {
-                        console.error('Error al copiar la nota como imagen:', error);
-                    });
+                    }).catch(function(error) { console.error('Error al copiar la nota como imagen:', error); });
                 });
             });
         }

--- a/Views/Note/_Delete.cshtml
+++ b/Views/Note/_Delete.cshtml
@@ -1,6 +1,6 @@
 ﻿@model LaLlamaDelBosque.Models.Note
 
-<h6>¿Desea eliminar la nota de @Model.Title?</h6>
+<h6>¿Desea eliminar el pago de @Model.Title?</h6>
 <p class="text-muted mb-3">Esta acción no se puede deshacer.</p>
 
 <form asp-action="Delete" asp-route-id="@Model.Id" method="post">

--- a/Views/Schedule/Turn.cshtml
+++ b/Views/Schedule/Turn.cshtml
@@ -1,55 +1,80 @@
 ﻿<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
 @model IEnumerable<LaLlamaDelBosque.Models.Schedule>
+@using LaLlamaDelBosque.Utils
 
 @{
     ViewData["Title"] = "Turnos";
+    var selectedDate = ViewBag.ShiftDate as string ?? DateTime.Today.ToString("yyyy-MM-dd");
 }
 
-<h1 class="display-4">@ViewData["Title"] del @DateTime.Today.ToShortDateString()</h1>
-
-<div class="table-responsive container">
-    <div class="row justify-content-md-center">
-        <div class="col-lg-6">
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>Id</th>
-                        <th>Nombre</th>
-                        <th>Horas</th>
-                        <th>Salario</th>
-                        <th>Terminar</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach(var item in Model)
-                    {
-                        <tr class="align-middle">
-                            <td>
-                                @item.Id
-                            </td>
-                            <td>
-                                @item.Name
-                            </td>
-                            <td>
-                                @item.Hours
-                            </td>
-                            <td>
-                                @item.Salary
-                            </td>
-                            <td style="text-align:center">
-                                <div class="btn-group mx-auto" role="group">
-                                    <!-- Check -->
-                                    <button type="button" class="btn" onclick="location.href='@Url.Action("Finish", "Schedule", new {Id= item.Id, Collection = item})'" >
-                                        <span class="material-icons" style="color: var(--dark);">check_circle</span>
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+<div class="container py-3">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+        <div>
+            <h1 class="display-6 mb-1">Turnos del día</h1>
+            <p class="text-muted mb-0">Cambia el día para revisar o cerrar turnos pendientes de fechas específicas.</p>
         </div>
+        <form asp-controller="Schedule" asp-action="Turn" method="get" class="card border-0 shadow-sm">
+            <div class="card-body p-2 d-flex gap-2 align-items-center">
+                <label class="visually-hidden" for="shiftDate">Turno / día</label>
+                <input id="shiftDate" name="shiftDate" type="date" class="form-control" value="@selectedDate" />
+                <button class="btn btn-dark d-inline-flex align-items-center gap-1" type="submit">
+                    <span class="material-icons" style="font-size:18px;">calendar_month</span>
+                    Ver
+                </button>
+            </div>
+        </form>
     </div>
+
+    @if(!Model.Any())
+    {
+        <div class="alert alert-info border-0 shadow-sm" role="alert">
+            No hay turnos pendientes para este día.
+        </div>
+    }
+    else
+    {
+        <div class="row row-cols-1 row-cols-lg-2 g-3">
+            @foreach(var item in Model)
+            {
+                <div class="col">
+                    <div class="card border-0 shadow-sm h-100">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+                                <div>
+                                    <div class="small text-muted text-uppercase">Colaborador</div>
+                                    <h4 class="mb-0">@item.Name</h4>
+                                </div>
+                                <span class="badge text-bg-warning">Pendiente</span>
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-6">
+                                    <div class="small text-muted">Entrada</div>
+                                    <div class="fw-semibold">@item.CreatedDate.ToShortTimeString()</div>
+                                </div>
+                                <div class="col-6">
+                                    <div class="small text-muted">Hasta ahora</div>
+                                    <div class="fw-semibold">@item.FinishDate.ToShortTimeString()</div>
+                                </div>
+                                <div class="col-6">
+                                    <div class="small text-muted">Horas</div>
+                                    <div class="h5 mb-0">@item.Hours</div>
+                                </div>
+                                <div class="col-6">
+                                    <div class="small text-muted">Salario</div>
+                                    <div class="h5 mb-0">@item.Salary.ToCRC()</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="card-footer bg-white border-0 pt-0">
+                            <button type="button" class="btn btn-success w-100 d-inline-flex justify-content-center align-items-center gap-2" onclick="location.href='@Url.Action("Finish", "Schedule", new { Id = item.Id })'">
+                                <span class="material-icons">check_circle</span>
+                                Terminar turno
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
 </div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -23,12 +23,16 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Credit" asp-action="Index">Créditos de Clientes</a>
                         </li>
-@*                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Schedule" asp-action="Index">Horarios</a>
-                        </li>*@
-@*                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Note" asp-action="Index">Notas / SINPEs</a>
-                        </li>*@
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                Operación
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Note" asp-action="Index">Pagos SINPE / Tarjeta</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Turn">Turnos del día</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Index">Horarios</a></li>
+                            </ul>
+                        </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 Tiempos


### PR DESCRIPTION
### Motivation
- Introduce explicit payment tracking (SINPE vs Tarjeta) and associate notes with a shift date to enable day-based reporting and totals.
- Improve the notes UI to better represent payments, provide an Excel-like payment sheet, and simplify creating/editing payments.
- Allow schedule turn views and finish actions to be filtered by a specific shift date instead of always using today.
- Normalize legacy notes missing a shift date to avoid null/default-date behavior.

### Description
- Added `NotePaymentMethod` enum and extended `Note` with `PaymentMethod` and `ShiftDate` properties and validation in `Models/NoteModel.cs`.
- Updated `NoteController` to accept `shiftDate` and `paymentMethod` in `Index`, filter notes by date and method, compute `SinpeTotal`, `CardTotal` and `GrandTotal`, set defaults on `Create`, persist `PaymentMethod` and `ShiftDate` on `Edit`, and preserve `shiftDate` in redirects; also set missing note `ShiftDate` values to `DateTime.Today` in `GetNotes`.
- Modified `ScheduleController.Turn` to accept a `shiftDate` parameter and filter schedules by `CreatedDate.Date`, and updated `Finish` to redirect back to the selected shift date.
- Reworked views under `Views/Note` (`Index`, `Create`, `Edit`, `_Delete`) to present payments UI, include payment method and shift date fields, add totals and a spreadsheet-style payment sheet, and improve styling and accessibility; added small JS/CSS tweaks and copy-as-image handling in `Index`.
- Reworked `Views/Schedule/Turn.cshtml` to allow selecting a shift date and present pending schedules in a card layout with a finish action.

### Testing
- Ran `dotnet build` to ensure the project compiles successfully and the build completed without errors.
- Executed the automated test suite with `dotnet test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c72ebb8a08330874eebb254ea8f76)