### PR TITLE
Support multiple cash closings per day, per-close payments and operations UI revamp

### DIFF
--- a/Controllers/NoteController.cs
+++ b/Controllers/NoteController.cs
@@ -15,12 +15,15 @@ namespace LaLlamaDelBosque.Controllers
         {
             _notes = GetNotes();
             _cashRegister = GetCashRegister();
+            MigrateLegacyPaymentAssignments();
         }
 
-        public IActionResult Index(string? searchText, DateTime? shiftDate, NotePaymentMethod? paymentMethod)
+        public IActionResult Index(string? searchText, DateTime? shiftDate, NotePaymentMethod? paymentMethod, int? closeId)
         {
             var selectedDate = shiftDate?.Date ?? DateTime.Today;
-            var dayNotes = _notes.Notes.Where(n => n.ShiftDate.Date == selectedDate).ToList();
+            var dayNotes = _notes.Notes
+                .Where(note => note.ShiftDate.Date == selectedDate && note.CashCloseId == closeId)
+                .ToList();
             var notes = dayNotes.AsEnumerable();
 
             if(!string.IsNullOrWhiteSpace(searchText))
@@ -37,13 +40,52 @@ namespace LaLlamaDelBosque.Controllers
             ViewBag.SearchText = searchText;
             ViewBag.ShiftDate = selectedDate.ToString("yyyy-MM-dd");
             ViewBag.PaymentMethod = paymentMethod;
-            ViewBag.SinpeTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.SINPE).Sum(n => n.Value);
-            ViewBag.CardTotal = filteredNotes.Where(n => n.PaymentMethod == NotePaymentMethod.Tarjeta).Sum(n => n.Value);
-            ViewBag.GrandTotal = filteredNotes.Sum(n => n.Value);
+            // The close summary must always represent the complete shift, even when the
+            // user is temporarily filtering the table.
+            ViewBag.SinpeTotal = dayNotes.Where(n => n.PaymentMethod == NotePaymentMethod.SINPE).Sum(n => n.Value);
+            ViewBag.CardTotal = dayNotes.Where(n => n.PaymentMethod == NotePaymentMethod.Tarjeta).Sum(n => n.Value);
+            ViewBag.GrandTotal = dayNotes.Sum(n => n.Value);
             ViewBag.PendingVerificationCount = dayNotes.Count(n => !n.IsVerified);
             ViewBag.AllPaymentsVerified = dayNotes.All(n => n.IsVerified);
-            ViewBag.CashClose = _cashRegister.CashClosings.FirstOrDefault(c => c.ShiftDate.Date == selectedDate) ?? new CashRegisterClose { ShiftDate = selectedDate };
+            var dailyClosings = _cashRegister.CashClosings
+                .Where(close => close.ShiftDate.Date == selectedDate)
+                .OrderBy(close => close.ClosedAt == default ? close.ShiftDate : close.ClosedAt)
+                .ToList();
+            var selectedClose = closeId.HasValue
+                ? dailyClosings.FirstOrDefault(close => close.Id == closeId.Value)
+                : null;
+
+            ViewBag.CashClose = selectedClose ?? new CashRegisterClose { ShiftDate = selectedDate };
+            ViewBag.DailyClosings = dailyClosings;
+            ViewBag.SelectedCloseId = selectedClose?.Id;
+            ViewBag.Collaborators = Constants.CurrentCollaborators;
             return View(filteredNotes);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult SavePayments(IFormCollection collection)
+        {
+            if(!DateTime.TryParse(collection["shiftDate"], out var shiftDate))
+                return BadRequest("La fecha del turno no es válida.");
+            _ = int.TryParse(collection["closeId"], out var closeId);
+            int? paymentCloseId = closeId > 0 ? closeId : null;
+            if(paymentCloseId.HasValue && !_cashRegister.CashClosings.Any(close => close.Id == paymentCloseId && close.ShiftDate.Date == shiftDate.Date))
+                return NotFound();
+
+            var submitted = new List<Note>();
+            submitted.AddRange(BuildPayments(collection, "sinpe", NotePaymentMethod.SINPE, shiftDate.Date, paymentCloseId));
+            submitted.AddRange(BuildPayments(collection, "card", NotePaymentMethod.Tarjeta, shiftDate.Date, paymentCloseId));
+
+            var nextId = _notes.Notes.Any() ? _notes.Notes.Max(note => note.Id) + 1 : 1;
+            foreach(var note in submitted.Where(note => note.Id <= 0))
+                note.Id = nextId++;
+
+            _notes.Notes.RemoveAll(note => note.ShiftDate.Date == shiftDate.Date && note.CashCloseId == paymentCloseId);
+            _notes.Notes.AddRange(submitted);
+            SetNotes(_notes);
+            TempData["SuccessMessage"] = "Movimientos guardados correctamente.";
+            return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd"), closeId = paymentCloseId });
         }
 
         [HttpGet]
@@ -128,20 +170,36 @@ namespace LaLlamaDelBosque.Controllers
         public IActionResult SaveCashClose(IFormCollection collection)
         {
             var shiftDate = DateTime.Parse(collection["shiftDate"]);
-            var shiftPayments = _notes.Notes.Where(n => n.ShiftDate.Date == shiftDate.Date).ToList();
+            _ = int.TryParse(collection["closeId"], out var closeId);
+            var closedBy = collection["closedBy"].ToString().Trim();
+            if(!Constants.CurrentCollaborators.Contains(closedBy, StringComparer.OrdinalIgnoreCase))
+            {
+                TempData["ErrorMessage"] = "Seleccione la colaboradora responsable del cierre.";
+                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd"), closeId = closeId > 0 ? closeId : null });
+            }
+            int? paymentCloseId = closeId > 0 ? closeId : null;
+            var shiftPayments = _notes.Notes
+                .Where(note => note.ShiftDate.Date == shiftDate.Date && note.CashCloseId == paymentCloseId)
+                .ToList();
             if(shiftPayments.Any(n => !n.IsVerified))
             {
                 TempData["ErrorMessage"] = "No puede hacer cambio de turno: hay pagos SINPE/Tarjeta sin check de comprobación.";
-                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd"), closeId = closeId > 0 ? closeId : null });
             }
 
-            var cashClose = _cashRegister.CashClosings.FirstOrDefault(c => c.ShiftDate.Date == shiftDate.Date);
+            var cashClose = closeId > 0
+                ? _cashRegister.CashClosings.FirstOrDefault(close => close.Id == closeId && close.ShiftDate.Date == shiftDate.Date)
+                : null;
+            if(closeId > 0 && cashClose is null)
+                return NotFound();
+
             if(cashClose is null)
             {
                 cashClose = new CashRegisterClose
                 {
                     Id = _cashRegister.CashClosings.Any() ? _cashRegister.CashClosings.Max(c => c.Id) + 1 : 1,
-                    ShiftDate = shiftDate.Date
+                    ShiftDate = shiftDate.Date,
+                    ClosedAt = DateTime.Now
                 };
                 _cashRegister.CashClosings.Add(cashClose);
             }
@@ -152,17 +210,42 @@ namespace LaLlamaDelBosque.Controllers
             cashClose.BankDeposit = ParseMoney(collection["bankDeposit"]);
             cashClose.PrizePayments = ParseMoney(collection["prizePayments"]);
             cashClose.AccountsReceivable = ParseMoney(collection["accountsReceivable"]);
+            cashClose.ProviderInitialCash = ParseMoney(collection["providerInitialCash"]);
+            cashClose.ProviderFinalCash = ParseMoney(collection["providerFinalCash"]);
+            cashClose.ClosedBy = Constants.CurrentCollaborators.First(name => name.Equals(closedBy, StringComparison.OrdinalIgnoreCase));
             cashClose.Providers = BuildProviders(collection);
 
             if(!cashClose.IsBalanced)
             {
-                TempData["ErrorMessage"] = $"La caja no cuadra. Diferencia: {cashClose.Difference.ToCRC()}. Revise efectivo, premios y proveedores.";
-                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+                TempData["ErrorMessage"] = $"El cierre no cuadra. Diferencia de caja: {cashClose.Difference.ToCRC()}. Diferencia de proveedores: {cashClose.ProviderDifference.ToCRC()}.";
+                return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd"), closeId = closeId > 0 ? closeId : null });
             }
 
+            foreach(var payment in shiftPayments)
+                payment.CashCloseId = cashClose.Id;
+
+            SetNotes(_notes);
             SetCashRegister(_cashRegister);
             TempData["SuccessMessage"] = "Caja guardada correctamente. Ya puede hacer el cambio de turno.";
-            return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd") });
+            return RedirectToAction(nameof(Index), new { shiftDate = shiftDate.ToString("yyyy-MM-dd"), closeId = cashClose.Id });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public IActionResult DeleteCashClose(int closeId)
+        {
+            var cashClose = _cashRegister.CashClosings.FirstOrDefault(close => close.Id == closeId);
+            if(cashClose is null)
+                return NotFound();
+
+            foreach(var payment in _notes.Notes.Where(note => note.CashCloseId == closeId))
+                payment.CashCloseId = null;
+
+            _cashRegister.CashClosings.Remove(cashClose);
+            SetNotes(_notes);
+            SetCashRegister(_cashRegister);
+            TempData["SuccessMessage"] = "Cierre eliminado. Sus movimientos quedaron disponibles para un nuevo cierre.";
+            return RedirectToAction(nameof(Index), new { shiftDate = cashClose.ShiftDate.ToString("yyyy-MM-dd") });
         }
 
         public IActionResult Search(SearchModel srcModel)
@@ -187,6 +270,38 @@ namespace LaLlamaDelBosque.Controllers
             }
 
             return providers;
+        }
+
+        private static List<Note> BuildPayments(IFormCollection collection, string prefix, NotePaymentMethod method, DateTime shiftDate, int? closeId)
+        {
+            var ids = collection[$"{prefix}Ids"];
+            var titles = collection[$"{prefix}Titles"];
+            var amounts = collection[$"{prefix}Amounts"];
+            var verifiedIds = collection[$"{prefix}Verified"].Select(value => value ?? "").ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var payments = new List<Note>();
+
+            for(var index = 0; index < Math.Max(ids.Count, Math.Max(titles.Count, amounts.Count)); index++)
+            {
+                var title = index < titles.Count ? titles[index]?.Trim() ?? "" : "";
+                var amount = index < amounts.Count ? ParseMoney(amounts[index]) : 0;
+                if(string.IsNullOrWhiteSpace(title) && amount <= 0)
+                    continue;
+
+                var idText = index < ids.Count ? ids[index] ?? "0" : "0";
+                _ = int.TryParse(idText, out var id);
+                payments.Add(new Note
+                {
+                    Id = id,
+                    CashCloseId = closeId,
+                    Title = title,
+                    Value = amount,
+                    PaymentMethod = method,
+                    ShiftDate = shiftDate,
+                    IsVerified = verifiedIds.Contains(idText)
+                });
+            }
+
+            return payments;
         }
 
         private static double ParseMoney(string? value)
@@ -223,6 +338,26 @@ namespace LaLlamaDelBosque.Controllers
         private static void SetCashRegister(CashRegisterModel cashRegister)
         {
             JsonFile.Write<CashRegisterModel>("CashRegister", cashRegister);
+        }
+
+        private void MigrateLegacyPaymentAssignments()
+        {
+            if(_cashRegister.DataVersion >= 1)
+                return;
+
+            foreach(var closingsByDate in _cashRegister.CashClosings.GroupBy(close => close.ShiftDate.Date))
+            {
+                if(closingsByDate.Count() != 1)
+                    continue;
+
+                var closeId = closingsByDate.Single().Id;
+                foreach(var note in _notes.Notes.Where(note => note.ShiftDate.Date == closingsByDate.Key && !note.CashCloseId.HasValue))
+                    note.CashCloseId = closeId;
+            }
+
+            _cashRegister.DataVersion = 1;
+            SetNotes(_notes);
+            SetCashRegister(_cashRegister);
         }
     }
 }

--- a/Controllers/ScheduleController.cs
+++ b/Controllers/ScheduleController.cs
@@ -37,6 +37,14 @@ namespace LaLlamaDelBosque.Controllers
             }
 
             ViewBag.ShiftDate = selectedDate.ToString("yyyy-MM-dd");
+            var cashRegister = JsonFile.Read<CashRegisterModel>("CashRegister", new CashRegisterModel());
+            ViewBag.DailyClosings = cashRegister.CashClosings
+                .Where(close => close.ShiftDate.Date == selectedDate)
+                .OrderBy(close => close.ClosedAt == default ? close.ShiftDate : close.ClosedAt)
+                .ToList();
+            ViewBag.ClosingCounts = cashRegister.CashClosings
+                .GroupBy(close => close.ShiftDate.Date)
+                .ToDictionary(group => group.Key, group => group.Count());
             return View(schedules.OrderBy(s => s.CreatedDate));
         }
 

--- a/Models/NoteModel.cs
+++ b/Models/NoteModel.cs
@@ -9,6 +9,7 @@ namespace LaLlamaDelBosque.Models
 
     public class CashRegisterModel
     {
+        public int DataVersion { get; set; }
         public List<CashRegisterClose> CashClosings { get; set; } = new List<CashRegisterClose>();
     }
 
@@ -16,6 +17,8 @@ namespace LaLlamaDelBosque.Models
     {
         public int Id { get; set; }
         public DateTime ShiftDate { get; set; } = DateTime.Today;
+        public DateTime ClosedAt { get; set; }
+        public string ClosedBy { get; set; } = "";
 
         public double InitialCash { get; set; }
         public double CashReceived { get; set; }
@@ -23,12 +26,16 @@ namespace LaLlamaDelBosque.Models
         public double BankDeposit { get; set; }
         public double PrizePayments { get; set; }
         public double AccountsReceivable { get; set; }
+        public double ProviderInitialCash { get; set; }
+        public double ProviderFinalCash { get; set; }
         public List<ProviderExpense> Providers { get; set; } = new List<ProviderExpense>();
 
         public double ProviderTotal => Math.Round(Providers.Sum(p => p.Amount), 2);
-        public double ExpectedCash => Math.Round(InitialCash + CashReceived - ProviderTotal - PrizePayments, 2);
+        public double ExpectedCash => Math.Round(InitialCash + CashReceived - PrizePayments, 2);
         public double Difference => Math.Round(FinalCash - ExpectedCash, 2);
-        public bool IsBalanced => Math.Abs(Difference) < 0.01;
+        public double ExpectedProviderCash => Math.Round(ProviderInitialCash - ProviderTotal, 2);
+        public double ProviderDifference => Math.Round(ProviderFinalCash - ExpectedProviderCash, 2);
+        public bool IsBalanced => Math.Abs(Difference) < 0.01 && Math.Abs(ProviderDifference) < 0.01;
     }
 
     public class ProviderExpense
@@ -46,6 +53,7 @@ namespace LaLlamaDelBosque.Models
     public class Note
     {
         public int Id { get; set; }
+        public int? CashCloseId { get; set; }
 
         [Required(ErrorMessage = "El campo es requerido")]
         [StringLength(50, ErrorMessage = "La longitud del título debe estar entre {2} y {1}.", MinimumLength = 2)]

--- a/Utils/Constants.cs
+++ b/Utils/Constants.cs
@@ -12,6 +12,8 @@
 
 		public static readonly List<string> BustedList = new() { "R", "3X", "5X", "7X" };
 
+        public static readonly IReadOnlyList<string> CurrentCollaborators = new[] { "Arlyn", "Tamara" };
+
         public static readonly Dictionary<string, double> NicaBustedMultipliers = new(StringComparer.OrdinalIgnoreCase)
 		{
 			{ "R", 200 },

--- a/Views/Note/Index.cshtml
+++ b/Views/Note/Index.cshtml
@@ -1,394 +1,82 @@
-﻿<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-
 @model IEnumerable<LaLlamaDelBosque.Models.Note>
 @using LaLlamaDelBosque.Utils
-
+@using System.Globalization
 @{
-    ViewData["Title"] = "Pagos del turno";
+    ViewData["Title"] = "Operaciones";
     var selectedDate = ViewBag.ShiftDate as string ?? DateTime.Today.ToString("yyyy-MM-dd");
-    NotePaymentMethod? selectedMethod = ViewBag.PaymentMethod as NotePaymentMethod?;
-    var paymentRows = Model.ToList();
-    var spreadsheetRows = Math.Max(28, paymentRows.Count);
-    var dateTitle = DateTime.TryParse(selectedDate, out var parsedShiftDate)
-        ? parsedShiftDate.ToString("dd-MMM", System.Globalization.CultureInfo.InvariantCulture)
-        : selectedDate;
-    var cashClose = ViewBag.CashClose as CashRegisterClose ?? new CashRegisterClose();
-    var providerRows = Math.Max(11, cashClose.Providers.Count);
-    var canCloseShift = (bool)(ViewBag.AllPaymentsVerified ?? false);
+    var date = DateTime.TryParse(selectedDate, out var parsed) ? parsed : DateTime.Today;
+    var payments = Model.ToList();
+    var sinpes = payments.Where(x => x.PaymentMethod == NotePaymentMethod.SINPE).ToList();
+    var cards = payments.Where(x => x.PaymentMethod == NotePaymentMethod.Tarjeta).ToList();
+    var cashClose = ViewBag.CashClose as CashRegisterClose ?? new CashRegisterClose { ShiftDate = date };
+    var dailyClosings = ViewBag.DailyClosings as List<CashRegisterClose> ?? new List<CashRegisterClose>();
+    int? selectedCloseId = ViewBag.SelectedCloseId as int?;
+    var canClose = (bool)(ViewBag.AllPaymentsVerified ?? true);
+    var collaborators = ViewBag.Collaborators as IReadOnlyList<string> ?? Array.Empty<string>();
 }
 
-<div class="container py-3">
-    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
-        <div>
-            <h1 class="display-6 mb-1">@ViewData["Title"]</h1>
-            <p class="text-muted mb-0">Control diario de SINPEs y tarjetas, pensado para reemplazar el Excel del cierre de turno.</p>
-        </div>
+<div class="container-fluid operations-page py-3">
+    <header class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-end gap-3 mb-4">
+        <div><span class="text-uppercase text-success fw-semibold small">Control de caja</span><h1 class="display-6 mb-1">Operaciones</h1><p class="text-muted mb-0">Registre todo directamente en las tablas. Los totales se calculan automáticamente.</p></div>
+        <form method="get" class="d-flex gap-2 align-items-end">
+            <div><label class="form-label small fw-semibold mb-1">Día del turno</label><input type="date" name="shiftDate" value="@selectedDate" class="form-control" /></div>
+            <button class="btn btn-dark" type="submit">Ver día</button>
+        </form>
+    </header>
 
-        <button type="button" class="btn btn-primary btn-lg d-inline-flex align-items-center gap-2"
-                onclick="location.href='@Url.Action("Create", "Note")'">
-            <span class="material-icons">add_circle</span>
-            Registrar pago
-        </button>
-    </div>
+    @if(TempData["ErrorMessage"] is string error) { <div class="alert alert-danger">@error</div> }
+    @if(TempData["SuccessMessage"] is string success) { <div class="alert alert-success">@success</div> }
 
-    <form asp-controller="Note" asp-action="Index" method="get" class="card border-0 shadow-sm mb-4">
-        <div class="card-body">
-            <div class="row g-3 align-items-end">
-                <div class="col-md-3">
-                    <label class="form-label fw-semibold">Turno / día</label>
-                    <input type="date" name="shiftDate" class="form-control" value="@selectedDate" />
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label fw-semibold">Buscar cliente</label>
-                    <input type="search" name="searchText" class="form-control" value="@ViewBag.SearchText" placeholder="Nombre del cliente..." />
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label fw-semibold">Método</label>
-                    <select name="paymentMethod" class="form-select">
-                        <option value="">Todos</option>
-                        @if(selectedMethod == NotePaymentMethod.SINPE)
-                        {
-                            <option value="SINPE" selected>SINPE</option>
-                        }
-                        else
-                        {
-                            <option value="SINPE">SINPE</option>
-                        }
-                        @if(selectedMethod == NotePaymentMethod.Tarjeta)
-                        {
-                            <option value="Tarjeta" selected>Tarjeta</option>
-                        }
-                        else
-                        {
-                            <option value="Tarjeta">Tarjeta</option>
-                        }
-                    </select>
-                </div>
-                <div class="col-md-2 d-grid">
-                    <button class="btn btn-dark" type="submit">Ver turno</button>
-                </div>
+    <form asp-action="SavePayments" method="post" id="payments-form" class="card border-0 shadow-sm mb-4">
+        @Html.AntiForgeryToken()<input type="hidden" name="shiftDate" value="@selectedDate" /><input type="hidden" name="closeId" value="@selectedCloseId" />
+        <div class="card-header bg-white border-0 pt-4 px-4"><div class="d-flex justify-content-between align-items-center"><div><h2 class="h5 mb-1">Movimientos de este cierre</h2><p class="text-muted small mb-0">Cada cierre conserva su propia lista de SINPE y tarjeta.</p></div><span class="badge text-bg-success">@(selectedCloseId.HasValue ? $"Cierre #{selectedCloseId}" : "Nuevo cierre") · @date.ToString("dd MMM yyyy", new CultureInfo("es-CR"))</span></div></div>
+        <div class="card-body px-4">
+            <ul class="nav nav-tabs" role="tablist">
+                <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#sinpe-pane" type="button">SINPE <span class="badge text-bg-primary ms-1" id="sinpe-count">@sinpes.Count</span></button></li>
+                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#card-pane" type="button">Tarjeta <span class="badge text-bg-success ms-1" id="card-count">@cards.Count</span></button></li>
+            </ul>
+            <div class="tab-content border border-top-0 rounded-bottom p-3">
+                @foreach(var setup in new[] { (Key: "sinpe", Pane: "sinpe-pane", Rows: sinpes, Active: true), (Key: "card", Pane: "card-pane", Rows: cards, Active: false) }) {
+                    <div class="tab-pane fade @(setup.Active ? "show active" : "")" id="@setup.Pane">
+                        <div class="table-responsive"><table class="table align-middle operation-table mb-2"><thead><tr><th>Cliente / referencia</th><th class="money-column">Monto</th><th class="check-column">Comprobado</th><th class="action-column"></th></tr></thead><tbody id="@setup.Key-rows">
+                        @foreach(var item in setup.Rows) { <tr><td><input type="hidden" name="@(setup.Key)Ids" value="@item.Id"/><input class="form-control" name="@(setup.Key)Titles" value="@item.Title" placeholder="Nombre o referencia" required /></td><td><input class="form-control money-input" name="@(setup.Key)Amounts" value="@item.Value.ToString(CultureInfo.InvariantCulture)" inputmode="decimal" min="0" type="number" step="0.01" required /></td><td class="text-center"><input class="form-check-input" name="@(setup.Key)Verified" value="@item.Id" type="checkbox" checked="@item.IsVerified" /></td><td><button type="button" class="btn btn-sm btn-outline-danger remove-row" title="Eliminar fila"><span class="material-icons">delete</span></button></td></tr> }
+                        </tbody><tfoot><tr><td class="fw-bold">Total</td><td class="fw-bold tab-total" id="@setup.Key-total">₡0</td><td colspan="2"></td></tr></tfoot></table></div>
+                        <button type="button" class="btn btn-outline-primary add-payment" data-prefix="@setup.Key"><span class="material-icons align-middle">add</span> Agregar fila</button>
+                    </div>
+                }
             </div>
+        </div>
+        <div class="card-footer bg-white border-0 px-4 pb-4 text-end"><button class="btn btn-primary btn-lg px-4" type="submit"><span class="material-icons align-middle me-1">save</span> Guardar movimientos</button></div>
+    </form>
+
+    <form asp-action="SaveCashClose" method="post" class="card border-0 shadow-sm mb-4" id="close-form">
+        @Html.AntiForgeryToken()<input type="hidden" name="shiftDate" value="@selectedDate" /><input type="hidden" name="closeId" value="@selectedCloseId" />
+        <div class="card-body p-4"><div class="d-flex justify-content-between gap-2 mb-3"><div><h2 class="h5 mb-1">@(selectedCloseId.HasValue ? $"Cierre #{selectedCloseId}" : "Nuevo cierre de caja")</h2><p class="text-muted small mb-0">Cada guardado nuevo crea un cierre independiente para este día.</p></div><span class="badge @(canClose ? "text-bg-success" : "text-bg-warning") align-self-start">@(canClose ? "Listo para cerrar" : $"{ViewBag.PendingVerificationCount} pendientes")</span></div>
+            @if(dailyClosings.Any()) { <div class="d-flex flex-wrap align-items-center gap-2 mb-4"><span class="small fw-semibold text-muted">Cierres de este día:</span>@foreach(var close in dailyClosings) { var closeTime = close.ClosedAt == default ? $"Cierre #{close.Id}" : close.ClosedAt.ToString("hh:mm tt", CultureInfo.InvariantCulture); var closeLabel = string.IsNullOrWhiteSpace(close.ClosedBy) ? closeTime : $"{closeTime} · {close.ClosedBy}"; <a class="btn btn-sm @(selectedCloseId == close.Id ? "btn-dark" : "btn-outline-secondary")" href="?shiftDate=@selectedDate&closeId=@close.Id">@closeLabel</a> }<a class="btn btn-sm btn-outline-success" href="?shiftDate=@selectedDate">+ Nuevo cierre</a></div> }
+            <div class="row g-4"><div class="col-xl-7"><div class="row g-3">
+                <div class="col-12"><label class="form-label fw-semibold" for="closedBy">Colaboradora responsable del cierre</label><select class="form-select form-select-lg" id="closedBy" name="closedBy" required><option value="">Seleccione a la colaboradora...</option>@foreach(var collaborator in collaborators) { if(cashClose.ClosedBy == collaborator) { <option value="@collaborator" selected>@collaborator</option> } else { <option value="@collaborator">@collaborator</option> } }</select><div class="form-text">El nombre quedará guardado en el historial de este cierre.</div></div>
+                @foreach(var field in new[] { ("initialCash","Caja inicial",cashClose.InitialCash), ("cashReceived","Efectivo recibido",cashClose.CashReceived), ("finalCash","Caja final contada",cashClose.FinalCash), ("providerInitialCash","Proveedores inicial",cashClose.ProviderInitialCash), ("providerFinalCash","Proveedores final contada",cashClose.ProviderFinalCash), ("bankDeposit","Depósito bancario",cashClose.BankDeposit), ("prizePayments","Pago de premios",cashClose.PrizePayments), ("accountsReceivable","Cuentas por cobrar",cashClose.AccountsReceivable) }) { <div class="col-md-4"><label class="form-label small fw-semibold">@field.Item2</label><input name="@field.Item1" class="form-control close-money" type="number" min="0" step="0.01" value="@field.Item3.ToString(CultureInfo.InvariantCulture)" /></div> }
+            </div>
+            <div class="d-flex justify-content-between align-items-center mt-4 mb-2"><div><h3 class="h6 mb-0">Proveedores</h3><span class="text-muted small">Agregue únicamente los gastos realizados.</span></div><button type="button" class="btn btn-sm btn-outline-primary" id="add-provider"><span class="material-icons align-middle">add</span> Agregar proveedor</button></div>
+            <div class="table-responsive"><table class="table align-middle"><thead><tr><th>Proveedor</th><th class="money-column">Monto</th><th class="action-column"></th></tr></thead><tbody id="provider-rows">
+                @foreach(var provider in cashClose.Providers) { <tr><td><input name="providerNames" class="form-control" value="@provider.Name" placeholder="Nombre del proveedor" required /></td><td><input name="providerAmounts" class="form-control provider-amount" type="number" min="0" step="0.01" value="@provider.Amount.ToString(CultureInfo.InvariantCulture)" required /></td><td><button type="button" class="btn btn-sm btn-outline-danger remove-row"><span class="material-icons">delete</span></button></td></tr> }
+            </tbody></table></div></div>
+            <aside class="col-xl-5"><div class="summary-panel rounded-3 p-3"><div class="summary-line"><span>Total SINPE</span><strong id="summary-sinpe">@(((double)ViewBag.SinpeTotal).ToCRC())</strong></div><div class="summary-line"><span>Total Tarjeta</span><strong id="summary-card">@(((double)ViewBag.CardTotal).ToCRC())</strong></div><div class="summary-line total"><span>Total movimientos</span><strong id="summary-grand">@(((double)ViewBag.GrandTotal).ToCRC())</strong></div><div class="summary-line"><span>Pagos a proveedores</span><strong id="summary-providers">@cashClose.ProviderTotal.ToCRC()</strong></div><hr/><div class="summary-line"><span>Caja esperada</span><strong id="summary-expected">@cashClose.ExpectedCash.ToCRC()</strong></div><div class="summary-line"><span>Diferencia de caja</span><strong id="summary-difference">@cashClose.Difference.ToCRC()</strong></div><div class="summary-line"><span>Proveedores esperado</span><strong id="summary-provider-expected">@cashClose.ExpectedProviderCash.ToCRC()</strong></div><div class="summary-line"><span>Diferencia de proveedores</span><strong id="summary-provider-difference">@cashClose.ProviderDifference.ToCRC()</strong></div></div><button type="submit" class="btn btn-success btn-lg w-100 mt-3" disabled="@(!canClose)"><span class="material-icons align-middle me-1">lock</span> @(selectedCloseId.HasValue ? "Actualizar cierre" : "Guardar nuevo cierre")</button></aside></div>
         </div>
     </form>
 
-    <div class="row g-3 mb-4">
-        <div class="col-md-4">
-            <div class="card border-0 shadow-sm h-100">
-                <div class="card-body">
-                    <div class="small text-muted text-uppercase">Total SINPE</div>
-                    <div class="h3 mb-0 text-primary">@(((double)ViewBag.SinpeTotal).ToCRC())</div>
-                </div>
+    @if(selectedCloseId.HasValue) {
+        <form asp-action="DeleteCashClose" method="post" id="delete-close-form" class="card border-danger shadow-sm">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="closeId" value="@selectedCloseId" />
+            <div class="card-body d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+                <div><h2 class="h6 text-danger mb-1">Eliminar este cierre</h2><p class="text-muted small mb-0">Los movimientos no se perderán: volverán a quedar disponibles para un nuevo cierre.</p></div>
+                <button type="submit" class="btn btn-outline-danger" data-confirm="¿Desea eliminar este cierre? Los movimientos quedarán disponibles para uno nuevo."><span class="material-icons align-middle me-1">delete</span> Eliminar cierre</button>
             </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card border-0 shadow-sm h-100">
-                <div class="card-body">
-                    <div class="small text-muted text-uppercase">Total Tarjeta</div>
-                    <div class="h3 mb-0 text-success">@(((double)ViewBag.CardTotal).ToCRC())</div>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
-            <div class="card border-0 shadow-sm h-100 bg-dark text-white">
-                <div class="card-body">
-                    <div class="small text-white-50 text-uppercase">Total del turno</div>
-                    <div class="h3 mb-0">@(((double)ViewBag.GrandTotal).ToCRC())</div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-    <div class="card border-0 shadow-sm mb-4">
-        <div class="card-body">
-            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
-                <div>
-                    <h2 class="h5 mb-1">Planilla del turno</h2>
-                    <p class="text-muted mb-0">Vista tipo Excel para revisar rápidamente montos, nombres y confirmación.</p>
-                </div>
-                <span class="badge text-bg-success fs-6">@dateTitle</span>
-            </div>
-            <div class="table-responsive">
-                <table class="table table-sm align-middle payment-sheet mb-0">
-                    <thead>
-                        <tr>
-                            <th class="sheet-date" colspan="4">@dateTitle</th>
-                        </tr>
-                        <tr>
-                            <th class="sheet-number"></th>
-                            <th>monto</th>
-                            <th>Nombre</th>
-                            <th>Si</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @for(var index = 0; index < spreadsheetRows; index++)
-                        {
-                            var row = index < paymentRows.Count ? paymentRows[index] : null;
-                            <tr>
-                                <td class="sheet-number">@(index + 1)</td>
-                                <td class="sheet-money">@(row is null ? "" : row.Value.ToCRC())</td>
-                                <td>@(row?.Title ?? "")</td>
-                                <td class="sheet-check">
-                                    @if(row is not null)
-                                    {
-                                        <form asp-controller="Note" asp-action="ToggleVerified" method="post" class="m-0">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="id" value="@row.Id" />
-                                            <input type="hidden" name="shiftDate" value="@selectedDate" />
-                                            <button type="submit" class="sheet-check-button @(row.IsVerified ? "is-checked" : "")" aria-label="Marcar pago comprobado">
-                                                @(row.IsVerified ? "✓" : "")
-                                            </button>
-                                        </form>
-                                    }
-                                </td>
-                            </tr>
-                        }
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td class="sheet-total-fill"></td>
-                            <td class="sheet-total-label">TOTAL</td>
-                            <td class="sheet-total-value">@(((double)ViewBag.GrandTotal).ToCRC())</td>
-                            <td class="sheet-total-fill"></td>
-                        </tr>
-                    </tfoot>
-                </table>
-            </div>
-        </div>
-    </div>
-
-
-    @if(TempData["ErrorMessage"] is string errorMessage)
-    {
-        <div class="alert alert-danger border-0 shadow-sm" role="alert">@errorMessage</div>
+        </form>
     }
-
-    <div class="card border-0 shadow-sm mb-4">
-        <div class="card-body">
-            <div class="d-flex flex-column flex-lg-row justify-content-between gap-2 mb-3">
-                <div>
-                    <h2 class="h5 mb-1">Caja / cambio de turno</h2>
-                    <p class="text-muted mb-0">Los checks deben estar completos y la caja debe cuadrar para permitir el cambio de personal.</p>
-                </div>
-                @if(canCloseShift)
-                {
-                    <span class="badge text-bg-success align-self-start">Pagos comprobados</span>
-                }
-                else
-                {
-                    <span class="badge text-bg-danger align-self-start">@ViewBag.PendingVerificationCount sin comprobar</span>
-                }
-            </div>
-
-            <form asp-controller="Note" asp-action="SaveCashClose" method="post">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="shiftDate" value="@selectedDate" />
-                <div class="row g-3">
-                    <div class="col-md-4">
-                        <label class="form-label">Caja inicial</label>
-                        <input name="initialCash" class="form-control" inputmode="decimal" value="@cashClose.InitialCash" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label">Efectivo recibido</label>
-                        <input name="cashReceived" class="form-control" inputmode="decimal" value="@cashClose.CashReceived" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label">Caja final contada</label>
-                        <input name="finalCash" class="form-control" inputmode="decimal" value="@cashClose.FinalCash" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label">Banco</label>
-                        <input name="bankDeposit" class="form-control" inputmode="decimal" value="@cashClose.BankDeposit" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label">Pago premios</label>
-                        <input name="prizePayments" class="form-control" inputmode="decimal" value="@cashClose.PrizePayments" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label">Cuentas por cobrar</label>
-                        <input name="accountsReceivable" class="form-control" inputmode="decimal" value="@cashClose.AccountsReceivable" />
-                    </div>
-                </div>
-
-                <div class="row g-4 mt-1">
-                    <div class="col-lg-7">
-                        <h3 class="h6 text-uppercase text-muted">Proveedores (gastos)</h3>
-                        <div class="table-responsive">
-                            <table class="table table-sm align-middle">
-                                <thead><tr><th>Proveedor</th><th style="width: 180px;">Monto</th></tr></thead>
-                                <tbody>
-                                    @for(var index = 0; index < providerRows; index++)
-                                    {
-                                        var provider = index < cashClose.Providers.Count ? cashClose.Providers[index] : new ProviderExpense();
-                                        <tr>
-                                            <td><input name="providerNames" class="form-control form-control-sm" value="@provider.Name" placeholder="Proveedor @(index + 1)" /></td>
-                                            <td><input name="providerAmounts" class="form-control form-control-sm" inputmode="decimal" value="@provider.Amount" /></td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="col-lg-5">
-                        <div class="list-group shadow-sm">
-                            <div class="list-group-item d-flex justify-content-between"><span>SINPEs comprobados</span><strong>@(((double)ViewBag.SinpeTotal).ToCRC())</strong></div>
-                            <div class="list-group-item d-flex justify-content-between"><span>Tarjetas comprobadas</span><strong>@(((double)ViewBag.CardTotal).ToCRC())</strong></div>
-                            <div class="list-group-item d-flex justify-content-between"><span>Suma proveedores</span><strong>@cashClose.ProviderTotal.ToCRC()</strong></div>
-                            <div class="list-group-item d-flex justify-content-between"><span>Caja esperada</span><strong>@cashClose.ExpectedCash.ToCRC()</strong></div>
-                            <div class="list-group-item d-flex justify-content-between @(cashClose.IsBalanced ? "list-group-item-success" : "list-group-item-warning")"><span>Diferencia</span><strong>@cashClose.Difference.ToCRC()</strong></div>
-                        </div>
-                        <button type="submit" class="btn btn-success w-100 mt-3" disabled="@(!canCloseShift)">Guardar caja y cambiar turno</button>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </div>
-
-    @if(TempData["SuccessMessage"] is string successMessage)
-    {
-        <div class="alert alert-success border-0 shadow-sm" role="alert">@successMessage</div>
-    }
-
-    @if(!Model.Any())
-    {
-        <div class="alert alert-info border-0 shadow-sm" role="alert">
-            No hay pagos registrados para este turno. Cambia el día o registra el primer SINPE/tarjeta.
-        </div>
-    }
-
-    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3">
-        @foreach(var item in Model)
-        {
-            var badgeClass = item.PaymentMethod == NotePaymentMethod.SINPE ? "text-bg-primary" : "text-bg-success";
-            <div class="col">
-                <div class="card h-100 border-0 shadow-sm" id="note-card-@item.Id">
-                    <div class="card-body">
-                        <div class="d-flex justify-content-between gap-3 mb-3">
-                            <div>
-                                <div class="small text-muted text-uppercase">Cliente</div>
-                                <h5 class="card-title mb-0">@item.Title</h5>
-                            </div>
-                            <div class="d-flex flex-column align-items-end gap-1">
-                                <span class="badge @badgeClass align-self-start">@item.PaymentMethod</span>
-                                <span class="badge @(item.IsVerified ? "text-bg-success" : "text-bg-warning")">@(item.IsVerified ? "Comprobado" : "Pendiente")</span>
-                            </div>
-                        </div>
-                        <div class="d-flex justify-content-between align-items-end">
-                            <div>
-                                <div class="small text-muted">Turno</div>
-                                <div>@item.ShiftDate.ToShortDateString()</div>
-                            </div>
-                            <div class="h4 mb-0">@item.Value.ToCRC()</div>
-                        </div>
-                    </div>
-                    <div class="card-footer bg-white border-0 pt-0">
-                        <div class="btn-group w-100" role="group" aria-label="Acciones de pago">
-                            <button type="button" class="btn btn-outline-dark" onclick="location.href='@Url.Action("Edit", "Note", new { id = item.Id })'">
-                                <span class="material-icons">edit</span>
-                            </button>
-                            <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteNoteModal-@item.Id">
-                                <span class="material-icons">delete</span>
-                            </button>
-                            <button type="button" class="btn btn-outline-primary" onclick="copyNoteAsImage('@item.Id')">
-                                <span class="material-icons">image</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="modal fade" id="deleteNoteModal-@item.Id" tabindex="-1" aria-labelledby="deleteNoteModalLabel-@item.Id" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered">
-                    <div class="modal-content border-0 shadow">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="deleteNoteModalLabel-@item.Id">Eliminar pago</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                            <partial name="_Delete" model="item"></partial>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        }
-    </div>
 </div>
-
-<div class="modal fade" id="copySuccessModal" tabindex="-1" aria-labelledby="copySuccessModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-sm modal-dialog-centered"><div class="modal-content border-0 shadow"><div class="modal-body text-center py-4"><span class="material-icons text-success mb-2" style="font-size: 32px;">check_circle</span><h6 class="mb-0" id="copySuccessModalLabel">¡Imagen copiada!</h6></div></div></div>
-</div>
-
-<style>
-    .payment-sheet {
-        max-width: 420px;
-        border-collapse: collapse;
-        font-size: 0.95rem;
-    }
-
-    .payment-sheet th,
-    .payment-sheet td {
-        border: 1px solid #111;
-        padding: 0.18rem 0.45rem;
-    }
-
-    .payment-sheet .sheet-date,
-    .payment-sheet thead th,
-    .payment-sheet .sheet-number,
-    .payment-sheet .sheet-total-fill {
-        background: #63be7b;
-        color: #000;
-        font-weight: 700;
-        text-align: center;
-    }
-
-    .payment-sheet tbody td:not(.sheet-number),
-    .payment-sheet .sheet-total-label,
-    .payment-sheet .sheet-total-value {
-        background: #d9ead3;
-    }
-
-    .payment-sheet .sheet-money,
-    .payment-sheet .sheet-total-value {
-        white-space: nowrap;
-    }
-
-    .payment-sheet .sheet-total-label,
-    .payment-sheet .sheet-total-value,
-    .payment-sheet .sheet-check {
-        text-align: center;
-    }
-
-    .sheet-check-button {
-        width: 1.5rem;
-        height: 1.5rem;
-        border: 1px solid #111;
-        background: #fff;
-        font-weight: 700;
-        line-height: 1;
-    }
-
-    .sheet-check-button.is-checked {
-        background: #63be7b;
-    }
-</style>
 
 @section Scripts {
-    <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
-    <script type="text/javascript">
-        function copyNoteAsImage(id) {
-            const card = document.getElementById('note-card-' + id);
-            if (!card) return;
-            html2canvas(card).then(function(canvas) {
-                canvas.toBlob(function(blob) {
-                    if (!blob || !navigator.clipboard || !navigator.clipboard.write) return;
-                    navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]).then(function() {
-                        const modal = new bootstrap.Modal(document.getElementById('copySuccessModal'));
-                        modal.show();
-                        setTimeout(function() { modal.hide(); }, 1800);
-                    }).catch(function(error) { console.error('Error al copiar la nota como imagen:', error); });
-                });
-            });
-        }
-    </script>
+    <script src="~/js/operations.js" asp-append-version="true"></script>
 }

--- a/Views/Schedule/Turn.cshtml
+++ b/Views/Schedule/Turn.cshtml
@@ -2,10 +2,18 @@
 
 @model IEnumerable<LaLlamaDelBosque.Models.Schedule>
 @using LaLlamaDelBosque.Utils
+@using System.Globalization
 
 @{
     ViewData["Title"] = "Turnos";
     var selectedDate = ViewBag.ShiftDate as string ?? DateTime.Today.ToString("yyyy-MM-dd");
+    var date = DateTime.TryParse(selectedDate, out var parsedDate) ? parsedDate : DateTime.Today;
+    var month = new DateTime(date.Year, date.Month, 1);
+    var previousMonth = month.AddMonths(-1).ToString("yyyy-MM-dd");
+    var nextMonth = month.AddMonths(1).ToString("yyyy-MM-dd");
+    var calendarStart = month.AddDays(-(int)month.DayOfWeek);
+    var dailyClosings = ViewBag.DailyClosings as List<CashRegisterClose> ?? new List<CashRegisterClose>();
+    var closingCounts = ViewBag.ClosingCounts as Dictionary<DateTime, int> ?? new Dictionary<DateTime, int>();
 }
 
 <div class="container py-3">
@@ -77,4 +85,54 @@
             }
         </div>
     }
+
+    <section class="card border-0 shadow-sm mt-4">
+        <div class="card-body p-4">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+                <div>
+                    <h2 class="h5 mb-1">Historial de cierres de caja</h2>
+                    <p class="text-muted small mb-0">Seleccione un día y luego el cierre que desea consultar o editar.</p>
+                </div>
+                <div class="btn-group">
+                    <a class="btn btn-outline-secondary" asp-action="Turn" asp-route-shiftDate="@previousMonth">‹</a>
+                    <span class="btn btn-light disabled text-capitalize">@month.ToString("MMMM yyyy", new CultureInfo("es-CR"))</span>
+                    <a class="btn btn-outline-secondary" asp-action="Turn" asp-route-shiftDate="@nextMonth">›</a>
+                </div>
+            </div>
+
+            <div class="closing-calendar mb-4">
+                <div class="calendar-weekdays">
+                    @foreach(var dayName in new[] { "Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb" }) { <span>@dayName</span> }
+                </div>
+                <div class="calendar-days">
+                    @for(var index = 0; index < 42; index++) {
+                        var day = calendarStart.AddDays(index);
+                        var closeCount = closingCounts.GetValueOrDefault(day.Date);
+                        <a asp-action="Turn" asp-route-shiftDate="@day.ToString("yyyy-MM-dd")" class="calendar-day @(day.Month != month.Month ? "outside" : "") @(closeCount > 0 ? "closed" : "") @(day.Date == date.Date ? "selected" : "")">
+                            <span>@day.Day</span>
+                            @if(closeCount > 0) { <small>@closeCount @(closeCount == 1 ? "cierre" : "cierres")</small> }
+                        </a>
+                    }
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <h3 class="h6 mb-0">Cierres del @date.ToString("dd MMMM yyyy", new CultureInfo("es-CR"))</h3>
+                <a class="btn btn-sm btn-success" asp-controller="Note" asp-action="Index" asp-route-shiftDate="@selectedDate">+ Crear cierre</a>
+            </div>
+            @if(!dailyClosings.Any()) {
+                <p class="text-muted mb-0">No hay cierres guardados para este día.</p>
+            } else {
+                <div class="list-group">
+                    @foreach(var close in dailyClosings) {
+                        var closeTime = close.ClosedAt == default ? $"Cierre #{close.Id}" : close.ClosedAt.ToString("hh:mm tt", CultureInfo.InvariantCulture);
+                        <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" asp-controller="Note" asp-action="Index" asp-route-shiftDate="@selectedDate" asp-route-closeId="@close.Id">
+                            <span><strong>@closeTime</strong><span class="text-muted ms-2">@(string.IsNullOrWhiteSpace(close.ClosedBy) ? "Sin responsable" : close.ClosedBy)</span></span>
+                            <span class="badge text-bg-dark">Ver o editar</span>
+                        </a>
+                    }
+                </div>
+            }
+        </div>
+    </section>
 </div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-4 app-navbar">
             <div class="container-fluid">
-                <a class="navbar-brand nav-link" asp-area="" asp-controller="Home" asp-action="Index">La Llama Del Bosque</a>
+                <a class="navbar-brand nav-link" asp-area="" asp-controller="Home" asp-action="Index">La Llama del Bosque · Inicio</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -21,37 +21,37 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Credit" asp-action="Index">Créditos de Clientes</a>
+                            <a class="nav-link" asp-area="" asp-controller="Credit" asp-action="Index">Cobros y créditos de clientes</a>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                Operación
+                                Caja y turnos
                             </a>
                             <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Note" asp-action="Index">Pagos SINPE / Tarjeta</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Turn">Turnos del día</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Index">Horarios</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Note" asp-action="Index">Registrar pagos y cerrar caja</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Turn">Turnos e historial de cierres</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Schedule" asp-action="Index">Administrar horarios de trabajo</a></li>
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                Tiempos
+                                Ventas de lotería
                             </a>
                             <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Lottery" asp-action="Create">Ventas por Sorteo</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Lottery" asp-action="Index">Listado de Ventas</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Award" asp-action="Index">Tabla de Premios</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Lottery" asp-action="Create">Registrar venta por sorteo</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Lottery" asp-action="Index">Consultar ventas registradas</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Award" asp-action="Index">Configurar premios</a></li>
                             </ul>
                         </li>
                         <li class="nav-item dropdown disabled">
                             <a class="nav-link dropdown-toggle disabled" asp-area="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                Productos
+                                Inventario y productos
                             </a>
                             <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Inventory" asp-action="Index">Inventario</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Family" asp-action="Index">Familias</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Department" asp-action="Index">Departamentos</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-controller="Supplier" asp-action="Index">Proveedores</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Inventory" asp-action="Index">Consultar inventario</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Family" asp-action="Index">Administrar familias de productos</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Department" asp-action="Index">Administrar departamentos</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-controller="Supplier" asp-action="Index">Administrar proveedores</a></li>
                                 
                             </ul>
                         </li>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -576,3 +576,110 @@ span.material-icons.star {
         font-size: 1.1rem;
         color: var(--primary-strong);
     }
+
+/* Operations */
+.operations-page {
+    max-width: 1400px;
+}
+
+.operation-table {
+    min-width: 650px;
+}
+
+.money-column {
+    width: 180px;
+}
+
+.check-column {
+    width: 120px;
+    text-align: center;
+}
+
+.action-column {
+    width: 55px;
+}
+
+.operations-page .material-icons {
+    font-size: 19px;
+    vertical-align: middle;
+}
+
+.summary-panel {
+    background: #f3f7f4;
+    border: 1px solid #dce8df;
+}
+
+.summary-line {
+    display: flex;
+    justify-content: space-between;
+    padding: .65rem .25rem;
+}
+
+.summary-line.total {
+    margin: .35rem -.4rem;
+    padding: .8rem .65rem;
+    color: #fff;
+    background: #173c2a;
+    border-radius: .5rem;
+}
+
+.calendar-weekdays,
+.calendar-days {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 5px;
+}
+
+.calendar-weekdays span {
+    padding: .4rem;
+    color: #6c757d;
+    font-size: .75rem;
+    font-weight: 700;
+    text-align: center;
+}
+
+.calendar-day {
+    display: flex;
+    min-height: 70px;
+    padding: .45rem;
+    color: #212529;
+    text-decoration: none;
+    border: 1px solid #e2e5e3;
+    border-radius: .5rem;
+    flex-direction: column;
+}
+
+.calendar-day:hover {
+    background: #f4fbf7;
+    border-color: #198754;
+}
+
+.calendar-day.outside {
+    opacity: .35;
+}
+
+.calendar-day.closed {
+    background: #e6f4eb;
+    border-color: #68ad7e;
+}
+
+.calendar-day.closed small {
+    margin-top: auto;
+    color: #157347;
+    font-weight: 600;
+}
+
+.calendar-day.selected {
+    outline: 2px solid #212529;
+}
+
+@media (max-width: 600px) {
+    .calendar-day {
+        min-height: 48px;
+        padding: .3rem;
+    }
+
+    .calendar-day small {
+        display: none;
+    }
+}

--- a/wwwroot/js/operations.js
+++ b/wwwroot/js/operations.js
@@ -1,0 +1,113 @@
+(() => {
+    const operationsPage = document.querySelector('.operations-page');
+    if (!operationsPage) return;
+
+    const formatMoney = value => new Intl.NumberFormat('es-CR', {
+        style: 'currency',
+        currency: 'CRC',
+        maximumFractionDigits: 2
+    }).format(Number(value) || 0);
+
+    const sumInputs = selector => [...document.querySelectorAll(selector)]
+        .reduce((total, input) => total + (Number(input.value) || 0), 0);
+
+    function recalculateSummary() {
+        const sinpeTotal = sumInputs('#sinpe-rows .money-input');
+        const cardTotal = sumInputs('#card-rows .money-input');
+        const providerTotal = sumInputs('.provider-amount');
+        const initialCash = Number(document.querySelector('[name=initialCash]').value) || 0;
+        const cashReceived = Number(document.querySelector('[name=cashReceived]').value) || 0;
+        const prizePayments = Number(document.querySelector('[name=prizePayments]').value) || 0;
+        const finalCash = Number(document.querySelector('[name=finalCash]').value) || 0;
+        const providerInitialCash = Number(document.querySelector('[name=providerInitialCash]').value) || 0;
+        const providerFinalCash = Number(document.querySelector('[name=providerFinalCash]').value) || 0;
+        const expectedCash = initialCash + cashReceived - prizePayments;
+        const expectedProviderCash = providerInitialCash - providerTotal;
+
+        document.querySelector('#sinpe-total').textContent = formatMoney(sinpeTotal);
+        document.querySelector('#card-total').textContent = formatMoney(cardTotal);
+        document.querySelector('#summary-sinpe').textContent = formatMoney(sinpeTotal);
+        document.querySelector('#summary-card').textContent = formatMoney(cardTotal);
+        document.querySelector('#summary-grand').textContent = formatMoney(sinpeTotal + cardTotal);
+        document.querySelector('#summary-providers').textContent = formatMoney(providerTotal);
+        document.querySelector('#summary-expected').textContent = formatMoney(expectedCash);
+        document.querySelector('#summary-difference').textContent = formatMoney(finalCash - expectedCash);
+        document.querySelector('#summary-provider-expected').textContent = formatMoney(expectedProviderCash);
+        document.querySelector('#summary-provider-difference').textContent = formatMoney(providerFinalCash - expectedProviderCash);
+    }
+
+    function createPaymentRow(prefix) {
+        const row = document.createElement('tr');
+        const key = `new-${Date.now()}-${crypto.randomUUID()}`;
+        row.innerHTML = `
+            <td>
+                <input type="hidden" name="${prefix}Ids" value="${key}">
+                <input class="form-control" name="${prefix}Titles" placeholder="Nombre o referencia" required>
+            </td>
+            <td>
+                <input class="form-control money-input" name="${prefix}Amounts" type="number"
+                       min="0" step="0.01" inputmode="decimal" required>
+            </td>
+            <td class="text-center">
+                <input class="form-check-input" name="${prefix}Verified" value="${key}" type="checkbox">
+            </td>
+            <td>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-row" title="Eliminar fila">
+                    <span class="material-icons">delete</span>
+                </button>
+            </td>`;
+        return row;
+    }
+
+    function createProviderRow() {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>
+                <input name="providerNames" class="form-control" placeholder="Nombre del proveedor" required>
+            </td>
+            <td>
+                <input name="providerAmounts" class="form-control provider-amount" type="number"
+                       min="0" step="0.01" required>
+            </td>
+            <td>
+                <button type="button" class="btn btn-sm btn-outline-danger remove-row" title="Eliminar proveedor">
+                    <span class="material-icons">delete</span>
+                </button>
+            </td>`;
+        return row;
+    }
+
+    document.querySelectorAll('.add-payment').forEach(button => {
+        button.addEventListener('click', () => {
+            document.querySelector(`#${button.dataset.prefix}-rows`)
+                .append(createPaymentRow(button.dataset.prefix));
+            recalculateSummary();
+        });
+    });
+
+    document.querySelector('#add-provider').addEventListener('click', () => {
+        document.querySelector('#provider-rows').append(createProviderRow());
+    });
+
+    document.addEventListener('click', event => {
+        const confirmationButton = event.target.closest('[data-confirm]');
+        if (confirmationButton && !window.confirm(confirmationButton.dataset.confirm)) {
+            event.preventDefault();
+            return;
+        }
+
+        const removeButton = event.target.closest('.remove-row');
+        if (!removeButton) return;
+
+        removeButton.closest('tr').remove();
+        recalculateSummary();
+    });
+
+    document.addEventListener('input', event => {
+        if (event.target.matches('.money-input, .provider-amount, .close-money')) {
+            recalculateSummary();
+        }
+    });
+
+    recalculateSummary();
+})();


### PR DESCRIPTION
### Motivation

- Enable multiple cash register closings per day and let payments be assigned to a specific closing so shifts can be split and audited independently.
- Improve the operations UI to manage SINPE/Tarjeta movements and cash closings in a single workflow with clearer summaries.

### Description

- Added per-payment association via `Note.CashCloseId`, extended `CashRegisterModel` with `DataVersion`, and enhanced `CashRegisterClose` with `ClosedAt`, `ClosedBy`, provider cash fields and provider balancing logic. 
- Updated business logic in `NoteController` to support `closeId` filtering in `Index`, a new `SavePayments` action to persist per-close payments, updated `SaveCashClose` to validate `closedBy`, attach payments to a close, and added `DeleteCashClose` and helper `BuildPayments`, plus a migration method `MigrateLegacyPaymentAssignments` that preserves existing data and bumps `DataVersion`.
- Reworked the operations UI in `Views/Note/Index.cshtml` to a tabbed payments editor and per-close close editor, added calendar and closing history to `Views/Schedule/Turn.cshtml`, adjusted navigation labels in `Views/Shared/_Layout.cshtml`, added interactive client behaviors in `wwwroot/js/operations.js`, and updated styling in `wwwroot/css/site.css`.
- Minor constants update adding `Constants.CurrentCollaborators` and adjusted expected cash calculation and provider balancing in the model.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5947e0c25483309953c464ebfa6a37)